### PR TITLE
ap_indirect: family sim with clean DGE/IGE/E partition + AM feasibility warnings

### DIFF
--- a/docs/examples/08_direct_indirect_effects.ipynb
+++ b/docs/examples/08_direct_indirect_effects.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "87a9f50a",
+   "id": "5ada09c8",
    "metadata": {},
    "source": [
     "# Direct vs Indirect Genetic Effects in `xftsim`\n",
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8c469eb",
+   "id": "0b652a25",
    "metadata": {},
    "source": [
     "## 0. Installation\n",
@@ -63,13 +63,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "402eb473",
+   "id": "7448f439",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:49.289065Z",
-     "iopub.status.busy": "2026-04-25T01:51:49.289009Z",
-     "iopub.status.idle": "2026-04-25T01:51:51.203199Z",
-     "shell.execute_reply": "2026-04-25T01:51:51.202686Z"
+     "iopub.execute_input": "2026-04-25T02:02:26.585653Z",
+     "iopub.status.busy": "2026-04-25T02:02:26.585592Z",
+     "iopub.status.idle": "2026-04-25T02:02:28.468591Z",
+     "shell.execute_reply": "2026-04-25T02:02:28.468255Z"
     }
    },
    "outputs": [
@@ -77,7 +77,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "xftsim: 0.3.0.dev111\n",
+      "xftsim: 0.3.0.dev112\n",
       "numpy:  1.26.4\n"
      ]
     }
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18942637",
+   "id": "ce563f99",
    "metadata": {},
    "source": [
     "## 1. The smallest useful simulation -- single trait, DGE + E\n",
@@ -120,13 +120,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "40557227",
+   "id": "a03e9be2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:51.204367Z",
-     "iopub.status.busy": "2026-04-25T01:51:51.204096Z",
-     "iopub.status.idle": "2026-04-25T01:51:51.631458Z",
-     "shell.execute_reply": "2026-04-25T01:51:51.630547Z"
+     "iopub.execute_input": "2026-04-25T02:02:28.469958Z",
+     "iopub.status.busy": "2026-04-25T02:02:28.469692Z",
+     "iopub.status.idle": "2026-04-25T02:02:28.888474Z",
+     "shell.execute_reply": "2026-04-25T02:02:28.887988Z"
     }
    },
    "outputs": [
@@ -134,9 +134,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "var(Y.G) = 0.516   target 0.5\n",
+      "var(Y.G) = 0.517   target 0.5\n",
       "var(Y.E) = 0.514   target 0.5\n",
-      "var(Y)   = 1.062     target ~1\n"
+      "var(Y)   = 1.042     target ~1\n"
      ]
     }
    ],
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "319498c7",
+   "id": "0696d2a9",
    "metadata": {},
    "source": [
     "**`genetic(eff)`** uses `standardized_matvec` internally: it\n",
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "643bb68f",
+   "id": "b99244e0",
    "metadata": {},
    "source": [
     "## 2. Two traits with correlated direct effects\n",
@@ -222,13 +222,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b63905d7",
+   "id": "9b3e2a67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:51.632740Z",
-     "iopub.status.busy": "2026-04-25T01:51:51.632632Z",
-     "iopub.status.idle": "2026-04-25T01:51:52.317458Z",
-     "shell.execute_reply": "2026-04-25T01:51:52.317019Z"
+     "iopub.execute_input": "2026-04-25T02:02:28.889641Z",
+     "iopub.status.busy": "2026-04-25T02:02:28.889486Z",
+     "iopub.status.idle": "2026-04-25T02:02:29.561614Z",
+     "shell.execute_reply": "2026-04-25T02:02:29.561090Z"
     }
    },
    "outputs": [
@@ -236,8 +236,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "var(TraitA.G) = 0.506   target 0.5\n",
-      "var(TraitB.G) = 0.516   target 0.5\n",
+      "var(TraitA.G) = 0.503   target 0.5\n",
+      "var(TraitB.G) = 0.509   target 0.5\n",
       "cor(A.G, B.G) = +0.316   target 0.3\n"
      ]
     }
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b69576b5",
+   "id": "1cb38823",
    "metadata": {},
    "source": [
     "## 3. Splitting the direct genetic score into transmitted halves\n",
@@ -302,20 +302,22 @@
     "on raw $\\{0,1\\}$ haplotype dosages -- no per-SNP standardization. To\n",
     "target a heritability of $h^2$ we must rescale $\\beta$ by\n",
     "$1/\\sqrt{2 p (1-p)}$ per SNP so that $\\sum_j 2 p_j (1-p_j)\\, \\beta_j^2\n",
-    "\\approx h^2$. Otherwise variance comes out at $h^2/2$ for uniform\n",
-    "$\\mathrm{MAF} = 0.5$."
+    "\\approx h^2$. Without the rescale we'd get\n",
+    "$\\mathrm{var}(\\mathrm{DGE}) \\approx \\langle 2 p (1-p) \\rangle \\cdot h^2$\n",
+    "(averaged over SNPs), which is below target -- e.g. $\\approx 0.39 h^2$\n",
+    "for $p \\sim U(0.1, 0.9)$ and exactly $h^2/2$ if every $p = 0.5$."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5778f659",
+   "id": "8225c25b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:52.318562Z",
-     "iopub.status.busy": "2026-04-25T01:51:52.318451Z",
-     "iopub.status.idle": "2026-04-25T01:51:52.704213Z",
-     "shell.execute_reply": "2026-04-25T01:51:52.703733Z"
+     "iopub.execute_input": "2026-04-25T02:02:29.563183Z",
+     "iopub.status.busy": "2026-04-25T02:02:29.563034Z",
+     "iopub.status.idle": "2026-04-25T02:02:29.951586Z",
+     "shell.execute_reply": "2026-04-25T02:02:29.951148Z"
     }
    },
    "outputs": [
@@ -323,10 +325,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "var(TraitB.DGE)        = 0.502   target 0.5\n",
-      "var(TraitB.T_mat)      = 0.253   target 0.25\n",
-      "var(TraitB.T_pat)      = 0.247   target 0.25\n",
-      "cov(T_mat, T_pat)      = +0.001   target ~0\n",
+      "var(TraitB.DGE)        = 0.508   target 0.5\n",
+      "var(TraitB.T_mat)      = 0.252   target 0.25\n",
+      "var(TraitB.T_pat)      = 0.246   target 0.25\n",
+      "cov(T_mat, T_pat)      = +0.005   target ~0\n",
       "max|T_mat+T_pat - DGE| = 0.00e+00   must be ~0\n"
      ]
     }
@@ -376,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9638a4e",
+   "id": "f4e38ffd",
    "metadata": {},
    "source": [
     "The two transmitted-allele components are uncorrelated under\n",
@@ -387,7 +389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a61bac5",
+   "id": "09cd045d",
    "metadata": {},
    "source": [
     "## 4. Vertical (indirect genetic) transmission with T/NT separation\n",
@@ -428,13 +430,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4c4ba9a7",
+   "id": "aa4e5460",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:52.705689Z",
-     "iopub.status.busy": "2026-04-25T01:51:52.705558Z",
-     "iopub.status.idle": "2026-04-25T01:51:52.924990Z",
-     "shell.execute_reply": "2026-04-25T01:51:52.924636Z"
+     "iopub.execute_input": "2026-04-25T02:02:29.952875Z",
+     "iopub.status.busy": "2026-04-25T02:02:29.952731Z",
+     "iopub.status.idle": "2026-04-25T02:02:30.174209Z",
+     "shell.execute_reply": "2026-04-25T02:02:30.173757Z"
     }
    },
    "outputs": [
@@ -442,13 +444,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "var(TraitB.DGE)            = 0.522   target 0.5\n",
+      "var(TraitB.DGE)            = 0.510   target 0.5\n",
       "var(TraitB.IGE)            = 0.402   target 0.4  (pinned)\n",
       "var(TraitB.E)              = 0.096   target 0.100\n",
-      "var(TraitB.NT_m)           = 0.253   target 0.25\n",
+      "var(TraitB.NT_m)           = 0.261   target 0.25\n",
       "max|PDGE_m - T_mat - NT_m| = 0.00e+00   must be ~0\n",
-      "cov(DGE, IGE)              = +0.327   theoretical ~+0.316\n",
-      "var(TraitB)                = 1.686   inflated by 2*cov(DGE,IGE)\n"
+      "cov(DGE, IGE)              = +0.323   theoretical ~+0.316\n",
+      "var(TraitB)                = 1.666   inflated by 2*cov(DGE,IGE)\n"
      ]
     }
    ],
@@ -505,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5190ce98",
+   "id": "aff34b62",
    "metadata": {},
    "source": [
     "The total $\\mathrm{var}(\\text{TraitB})$ is genuinely above 1:\n",
@@ -521,7 +523,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "522f307a",
+   "id": "1a319892",
    "metadata": {},
    "source": [
     "## 5. Estimating direct and indirect coefficients\n",
@@ -541,10 +543,16 @@
     "$$\n",
     "\n",
     "where\n",
-    "$\\alpha_m = \\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{mom}} / \\mathrm{var}(\\text{parental DGE})}$\n",
+    "$\\alpha_m = \\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{mom}} / \\mathrm{var}(\\mathrm{PDGE}_m)}$\n",
     "is the realized coefficient on the parent's *raw* DGE in the IGE\n",
-    "channel after the internal `normalize=True` step. So an OLS regression\n",
-    "of child phenotype on the four columns recovers:\n",
+    "channel after the internal `normalize=True` step.\n",
+    "$\\mathrm{var}(\\mathrm{PDGE}_m)$ here is the variance *as the children\n",
+    "see it* (mothers indexed by `maternal_idx`, with offspring multiplicity)\n",
+    "-- which is what the architecture standardizes against\n",
+    "(`narch.py:553-563`). Under random mating this is essentially the same\n",
+    "as the full parent-generation variance; under assortative mating the\n",
+    "two diverge and only the offspring-weighted form stays correct. So an\n",
+    "OLS regression of child phenotype on the four columns recovers:\n",
     "\n",
     "$$\n",
     "\\hat\\beta(T_{\\text{mat}}) = 1 + \\alpha_m, \\qquad\n",
@@ -566,13 +574,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "263b1ba6",
+   "id": "406e7a05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:52.926244Z",
-     "iopub.status.busy": "2026-04-25T01:51:52.926098Z",
-     "iopub.status.idle": "2026-04-25T01:51:53.773873Z",
-     "shell.execute_reply": "2026-04-25T01:51:53.773224Z"
+     "iopub.execute_input": "2026-04-25T02:02:30.175491Z",
+     "iopub.status.busy": "2026-04-25T02:02:30.175396Z",
+     "iopub.status.idle": "2026-04-25T02:02:31.015308Z",
+     "shell.execute_reply": "2026-04-25T02:02:31.014919Z"
     }
    },
    "outputs": [
@@ -606,37 +614,37 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>intercept</th>\n",
-       "      <td>1.278792</td>\n",
+       "      <td>1.278765</td>\n",
        "      <td>0.005012</td>\n",
-       "      <td>255.141930</td>\n",
+       "      <td>255.148004</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_mat</th>\n",
-       "      <td>1.631543</td>\n",
-       "      <td>0.004469</td>\n",
-       "      <td>365.043088</td>\n",
+       "      <td>1.636028</td>\n",
+       "      <td>0.004480</td>\n",
+       "      <td>365.213314</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_pat</th>\n",
-       "      <td>1.625945</td>\n",
-       "      <td>0.004432</td>\n",
-       "      <td>366.843860</td>\n",
+       "      <td>1.631720</td>\n",
+       "      <td>0.004496</td>\n",
+       "      <td>362.963365</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_m</th>\n",
-       "      <td>0.634427</td>\n",
-       "      <td>0.004509</td>\n",
-       "      <td>140.701101</td>\n",
+       "      <td>0.629876</td>\n",
+       "      <td>0.004480</td>\n",
+       "      <td>140.596507</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_f</th>\n",
-       "      <td>0.632041</td>\n",
-       "      <td>0.004453</td>\n",
-       "      <td>141.934510</td>\n",
+       "      <td>0.626246</td>\n",
+       "      <td>0.004452</td>\n",
+       "      <td>140.662289</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -645,11 +653,11 @@
       ],
       "text/plain": [
        "           estimate  std_error     t_value  p_value\n",
-       "intercept  1.278792   0.005012  255.141930      0.0\n",
-       "T_mat      1.631543   0.004469  365.043088      0.0\n",
-       "T_pat      1.625945   0.004432  366.843860      0.0\n",
-       "NT_m       0.634427   0.004509  140.701101      0.0\n",
-       "NT_f       0.632041   0.004453  141.934510      0.0"
+       "intercept  1.278765   0.005012  255.148004      0.0\n",
+       "T_mat      1.636028   0.004480  365.213314      0.0\n",
+       "T_pat      1.631720   0.004496  362.963365      0.0\n",
+       "NT_m       0.629876   0.004480  140.596507      0.0\n",
+       "NT_f       0.626246   0.004452  140.662289      0.0"
       ]
      },
      "execution_count": 6,
@@ -701,7 +709,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9569e75c",
+   "id": "34220796",
    "metadata": {},
    "source": [
     "Compare against the theoretical targets. We seeded the IGE\n",
@@ -710,20 +718,23 @@
     "raw parental DGE is\n",
     "\n",
     "$$\n",
-    "\\alpha = \\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{parent}} / \\mathrm{var}(\\text{parental DGE})}.\n",
-    "$$"
+    "\\alpha_{\\{m,f\\}} = \\sqrt{B_{\\text{vIGE}} \\cdot p_{\\{\\text{mom},\\text{dad}\\}} / \\mathrm{var}(\\mathrm{PDGE}_{\\{m,f\\}})},\n",
+    "$$\n",
+    "\n",
+    "with `PDGE_m` and `PDGE_f` indexed by `maternal_idx`/`paternal_idx`\n",
+    "inside the children's data."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "aac7b848",
+   "id": "3aee22b3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:53.775149Z",
-     "iopub.status.busy": "2026-04-25T01:51:53.775056Z",
-     "iopub.status.idle": "2026-04-25T01:51:53.780899Z",
-     "shell.execute_reply": "2026-04-25T01:51:53.780348Z"
+     "iopub.execute_input": "2026-04-25T02:02:31.016731Z",
+     "iopub.status.busy": "2026-04-25T02:02:31.016615Z",
+     "iopub.status.idle": "2026-04-25T02:02:31.022188Z",
+     "shell.execute_reply": "2026-04-25T02:02:31.021865Z"
     }
    },
    "outputs": [
@@ -757,32 +768,32 @@
        "    <tr>\n",
        "      <th>intercept</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>1.278792</td>\n",
+       "      <td>1.278765</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_mat</th>\n",
-       "      <td>1.630436</td>\n",
-       "      <td>1.631543</td>\n",
-       "      <td>0.001107</td>\n",
+       "      <td>1.631808</td>\n",
+       "      <td>1.636028</td>\n",
+       "      <td>0.004220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_pat</th>\n",
-       "      <td>1.630436</td>\n",
-       "      <td>1.625945</td>\n",
-       "      <td>-0.004492</td>\n",
+       "      <td>1.629113</td>\n",
+       "      <td>1.631720</td>\n",
+       "      <td>0.002607</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_m</th>\n",
-       "      <td>0.630436</td>\n",
-       "      <td>0.634427</td>\n",
-       "      <td>0.003990</td>\n",
+       "      <td>0.631808</td>\n",
+       "      <td>0.629876</td>\n",
+       "      <td>-0.001933</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_f</th>\n",
-       "      <td>0.630436</td>\n",
-       "      <td>0.632041</td>\n",
-       "      <td>0.001605</td>\n",
+       "      <td>0.629113</td>\n",
+       "      <td>0.626246</td>\n",
+       "      <td>-0.002867</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -790,11 +801,11 @@
       ],
       "text/plain": [
        "           theoretical  estimate     error\n",
-       "intercept          NaN  1.278792       NaN\n",
-       "T_mat         1.630436  1.631543  0.001107\n",
-       "T_pat         1.630436  1.625945 -0.004492\n",
-       "NT_m          0.630436  0.634427  0.003990\n",
-       "NT_f          0.630436  0.632041  0.001605"
+       "intercept          NaN  1.278765       NaN\n",
+       "T_mat         1.631808  1.636028  0.004220\n",
+       "T_pat         1.629113  1.631720  0.002607\n",
+       "NT_m          0.631808  0.629876 -0.001933\n",
+       "NT_f          0.629113  0.626246 -0.002867"
       ]
      },
      "execution_count": 7,
@@ -803,9 +814,11 @@
     }
    ],
    "source": [
-    "parent_dge_var = sim_big.phenotype_history[0][\"TraitB.DGE\"].var()\n",
-    "alpha_m = np.sqrt(B_vIGE * p_mom / parent_dge_var)\n",
-    "alpha_f = np.sqrt(B_vIGE * p_dad / parent_dge_var)\n",
+    "# Use the offspring-weighted parental variance, matching the architecture's\n",
+    "# normalize=True step. Under random mating this is ~equal to the\n",
+    "# full parent-generation variance; AM would make them differ.\n",
+    "alpha_m = np.sqrt(B_vIGE * p_mom / ph[\"TraitB.PDGE_m\"].var())\n",
+    "alpha_f = np.sqrt(B_vIGE * p_dad / ph[\"TraitB.PDGE_f\"].var())\n",
     "\n",
     "theory = pd.DataFrame({\n",
     "    \"theoretical\": [np.nan, 1 + alpha_m, 1 + alpha_f, alpha_m, alpha_f],\n",
@@ -817,7 +830,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d74af23",
+   "id": "41821cce",
    "metadata": {},
    "source": [
     "**Direct effect** (per allele unit of polygenic score) is recovered\n",
@@ -836,13 +849,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "895b9912",
+   "id": "e0968c4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:53.781969Z",
-     "iopub.status.busy": "2026-04-25T01:51:53.781882Z",
-     "iopub.status.idle": "2026-04-25T01:51:53.799039Z",
-     "shell.execute_reply": "2026-04-25T01:51:53.798733Z"
+     "iopub.execute_input": "2026-04-25T02:02:31.023013Z",
+     "iopub.status.busy": "2026-04-25T02:02:31.022850Z",
+     "iopub.status.idle": "2026-04-25T02:02:31.037711Z",
+     "shell.execute_reply": "2026-04-25T02:02:31.037449Z"
     }
    },
    "outputs": [
@@ -850,7 +863,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "naive direct estimate = 1.635  (should be ~1.630, conflating direct + indirect)\n"
+      "naive direct estimate = 1.646  (should be ~1.632, conflating direct + indirect)\n"
      ]
     }
    ],
@@ -862,7 +875,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00e2c2d3",
+   "id": "9afbd22d",
    "metadata": {},
    "source": [
     "## 6. Layering on assortative mating\n",
@@ -887,13 +900,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1dcb44ad",
+   "id": "4fa13ef6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:51:53.800679Z",
-     "iopub.status.busy": "2026-04-25T01:51:53.800269Z",
-     "iopub.status.idle": "2026-04-25T01:51:56.452195Z",
-     "shell.execute_reply": "2026-04-25T01:51:56.451694Z"
+     "iopub.execute_input": "2026-04-25T02:02:31.038474Z",
+     "iopub.status.busy": "2026-04-25T02:02:31.038383Z",
+     "iopub.status.idle": "2026-04-25T02:02:33.656551Z",
+     "shell.execute_reply": "2026-04-25T02:02:33.656083Z"
     }
    },
    "outputs": [
@@ -991,7 +1004,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6661949",
+   "id": "55bcb5b1",
    "metadata": {},
    "source": [
     "**Reading the matrix:** under exchangeable cross-trait AM with\n",

--- a/docs/examples/08_direct_indirect_effects.ipynb
+++ b/docs/examples/08_direct_indirect_effects.ipynb
@@ -1,0 +1,991 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e5876605",
+   "metadata": {},
+   "source": [
+    "# Direct vs Indirect Genetic Effects in `xftsim`\n",
+    "\n",
+    "A walkthrough of how to:\n",
+    "\n",
+    "1. Install the `ap_indirect` development branch.\n",
+    "2. Build family-based simulations of increasing complexity using the new\n",
+    "   formula DSL — DGE-only, two correlated traits, per-haplotype\n",
+    "   transmitted scores, vertical (indirect) transmission with a\n",
+    "   variance-pinned IGE channel.\n",
+    "3. Verify each stage's variance / covariance / identity targets.\n",
+    "4. Estimate direct and indirect coefficients post-hoc from the simulated\n",
+    "   trios via Kong-style non-transmitted-coefficient (NTC) regression.\n",
+    "5. Layer in assortative mating with single- and cross-trait targets, and\n",
+    "   see what happens when the per-cell exchangeable correlation becomes\n",
+    "   infeasible.\n",
+    "\n",
+    "The architecture decisions made here (sourcing IGE from the parent's\n",
+    "*full* DGE for biological realism while separately tracking the\n",
+    "non-transmitted parental allele score for clean identification) are\n",
+    "explained inline as we build the formula up."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4087a5d4",
+   "metadata": {},
+   "source": [
+    "## 0. Installation\n",
+    "\n",
+    "The `ap_indirect` branch is on top of the `ajay` rewrite — numpy-backed\n",
+    "data structures, a formula DSL for architectures, and a new simulation\n",
+    "loop. None of the legacy xarray-based components are needed for the\n",
+    "work in this notebook.\n",
+    "\n",
+    "### Option A — clone and use the dev script\n",
+    "\n",
+    "```bash\n",
+    "git clone -b ap_indirect https://github.com/border-lab/xftsim.git\n",
+    "cd xftsim\n",
+    "./scripts/setup-dev.sh        # creates .venv from requirements-lock.txt\n",
+    "source .venv/bin/activate\n",
+    "```\n",
+    "\n",
+    "### Option B — pip install directly into an existing env\n",
+    "\n",
+    "```bash\n",
+    "pip install \"git+https://github.com/border-lab/xftsim.git@ap_indirect#egg=xftsim[legacy,dev]\"\n",
+    "```\n",
+    "\n",
+    "The `[legacy]` extra pulls in `sgkit` (only needed if you load real zarr\n",
+    "genomes — not used here). `[dev]` pulls in pytest etc.\n",
+    "\n",
+    "### Smoke check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "76ac340b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:48.952292Z",
+     "iopub.status.busy": "2026-04-25T01:40:48.952226Z",
+     "iopub.status.idle": "2026-04-25T01:40:50.867262Z",
+     "shell.execute_reply": "2026-04-25T01:40:50.866766Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "xftsim: 0.3.0.dev110\n",
+      "numpy:  1.26.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "import xftsim\n",
+    "import numpy as np, pandas as pd\n",
+    "import statsmodels.api as sm\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "print(\"xftsim:\", xftsim.__version__)\n",
+    "print(\"numpy: \", np.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e567c86",
+   "metadata": {},
+   "source": [
+    "## 1. The smallest useful simulation — single trait, DGE + E\n",
+    "\n",
+    "Every architecture is a string in the formula DSL plus an `effects` dict.\n",
+    "The simplest possible model is one trait with a direct genetic component\n",
+    "and additive environmental noise:\n",
+    "\n",
+    "```\n",
+    "Y.G ~ genetic(eff)\n",
+    "Y.E ~ noise(var_E)\n",
+    "Y   ~ Y.G + Y.E\n",
+    "```\n",
+    "\n",
+    "`Y.G` and `Y.E` are stored as separate columns in the per-generation\n",
+    "phenotype dict, so the variance partition is recoverable by name. `Y` is\n",
+    "just an arithmetic aggregation node.\n",
+    "\n",
+    "For uniform-AF founders with MAF drawn from `U(0.1, 0.9)`, picking\n",
+    "`var_E = 1 - h²` makes `var(Y) ≈ 1`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "56e7de7e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:50.868341Z",
+     "iopub.status.busy": "2026-04-25T01:40:50.868073Z",
+     "iopub.status.idle": "2026-04-25T01:40:51.308578Z",
+     "shell.execute_reply": "2026-04-25T01:40:51.308049Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "var(Y.G) = 0.516   target 0.5\n",
+      "var(Y.E) = 0.514   target 0.5\n",
+      "var(Y)   = 1.040     target ~1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xftsim.founders import founder_haplotypes_uniform_AFs\n",
+    "from xftsim.neffect import AdditiveEffects\n",
+    "from xftsim.narch import Architecture\n",
+    "from xftsim.nmate import RandomMating\n",
+    "from xftsim.reproduce import RecombinationMap\n",
+    "from xftsim.nsim import NSimulation\n",
+    "\n",
+    "np.random.seed(0)\n",
+    "\n",
+    "n_fam = 4_000\n",
+    "m     = 2_000\n",
+    "h2    = 0.5\n",
+    "\n",
+    "founder_hap = founder_haplotypes_uniform_AFs(n=2 * n_fam, m=m)\n",
+    "eff = AdditiveEffects.from_h2(h2=h2, m=m, seed=1)\n",
+    "\n",
+    "arch = Architecture(formula=\"\"\"\n",
+    "Y.G ~ genetic(eff)\n",
+    "Y.E ~ noise({varE})\n",
+    "Y   ~ Y.G + Y.E\n",
+    "\"\"\".format(varE=1 - h2),\n",
+    "    effects={\"eff\": eff},\n",
+    ")\n",
+    "\n",
+    "sim = NSimulation(\n",
+    "    founder_haplotypes=founder_hap,\n",
+    "    architecture=arch,\n",
+    "    mating_regime=RandomMating(offspring_per_pair=2),\n",
+    "    recombination_map=RecombinationMap.constant_map(m=m, p=0.5),\n",
+    "    seed=1,\n",
+    ")\n",
+    "sim.run(2)   # gen 0 (founders) + gen 1 (offspring)\n",
+    "\n",
+    "ph = sim.phenotype_history[1]\n",
+    "print(f\"var(Y.G) = {ph['Y.G'].var():.3f}   target {h2}\")\n",
+    "print(f\"var(Y.E) = {ph['Y.E'].var():.3f}   target {1-h2}\")\n",
+    "print(f\"var(Y)   = {ph['Y'].var():.3f}     target ~1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79427ec7",
+   "metadata": {},
+   "source": [
+    "**`genetic(eff)`** uses `standardized_matvec` internally — it\n",
+    "centers and scales each column to unit variance under HWE before\n",
+    "multiplying by the per-allele effects. So `AdditiveEffects.from_h2(h2=...,\n",
+    "m=...)` draws `β ~ N(0, h²/m)` and the resulting genetic value variance\n",
+    "hits `h²` directly. Good for quick experiments.\n",
+    "\n",
+    "We'll switch to the **raw-dosage** path (`haplotypeGenetic`) in §3 — it\n",
+    "gives us per-haplotype scores but at the cost of having to rescale\n",
+    "`β` by `1/sqrt(2p(1-p))` ourselves."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a678c85b",
+   "metadata": {},
+   "source": [
+    "## 2. Two traits with correlated direct effects\n",
+    "\n",
+    "To put a target genetic correlation `ρ_g` between the two traits, draw\n",
+    "the per-SNP `β` matrix from a bivariate normal with off-diagonal\n",
+    "correlation `ρ_g`:\n",
+    "\n",
+    "`β ~ N(0, Σ/m)` with `Σ = [[h²_A, ρ_g·sqrt(h²_A·h²_B)], [ρ_g·sqrt(h²_A·h²_B), h²_B]]`\n",
+    "\n",
+    "Then register one `AdditiveEffects` per column. The per-trait\n",
+    "heritabilities still hit `h²_A` and `h²_B`, and the cross-trait DGE\n",
+    "covariance carries through."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8bc98754",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:51.309696Z",
+     "iopub.status.busy": "2026-04-25T01:40:51.309577Z",
+     "iopub.status.idle": "2026-04-25T01:40:51.993539Z",
+     "shell.execute_reply": "2026-04-25T01:40:51.993174Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "var(TraitA.G) = 0.515   target 0.5\n",
+      "var(TraitB.G) = 0.511   target 0.5\n",
+      "cor(A.G, B.G) = +0.317   target 0.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "def draw_bivariate_betas(h2_A, h2_B, rho_g, m, seed):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    Sigma = np.array([\n",
+    "        [h2_A,                      rho_g * np.sqrt(h2_A * h2_B)],\n",
+    "        [rho_g * np.sqrt(h2_A*h2_B), h2_B],\n",
+    "    ]) / m\n",
+    "    return rng.multivariate_normal(mean=[0.0, 0.0], cov=Sigma, size=m)\n",
+    "\n",
+    "h2_A, h2_B, rho_g = 0.5, 0.5, 0.3\n",
+    "betas = draw_bivariate_betas(h2_A, h2_B, rho_g, m=m, seed=2)\n",
+    "\n",
+    "eff_A = AdditiveEffects.from_array(betas[:, 0])  # standardized convention\n",
+    "eff_B = AdditiveEffects.from_array(betas[:, 1])\n",
+    "\n",
+    "arch = Architecture(formula=\"\"\"\n",
+    "TraitA.G ~ genetic(eff_A)\n",
+    "TraitA.E ~ noise({eA})\n",
+    "TraitA   ~ TraitA.G + TraitA.E\n",
+    "\n",
+    "TraitB.G ~ genetic(eff_B)\n",
+    "TraitB.E ~ noise({eB})\n",
+    "TraitB   ~ TraitB.G + TraitB.E\n",
+    "\"\"\".format(eA=1-h2_A, eB=1-h2_B),\n",
+    "    effects={\"eff_A\": eff_A, \"eff_B\": eff_B},\n",
+    ")\n",
+    "\n",
+    "founder_hap = founder_haplotypes_uniform_AFs(n=2*n_fam, m=m)\n",
+    "sim = NSimulation(\n",
+    "    founder_haplotypes=founder_hap,\n",
+    "    architecture=arch,\n",
+    "    mating_regime=RandomMating(offspring_per_pair=2),\n",
+    "    recombination_map=RecombinationMap.constant_map(m=m, p=0.5),\n",
+    "    seed=2,\n",
+    ")\n",
+    "sim.run(2)\n",
+    "\n",
+    "ph = sim.phenotype_history[1]\n",
+    "gA, gB = ph[\"TraitA.G\"], ph[\"TraitB.G\"]\n",
+    "print(f\"var(TraitA.G) = {gA.var():.3f}   target {h2_A}\")\n",
+    "print(f\"var(TraitB.G) = {gB.var():.3f}   target {h2_B}\")\n",
+    "print(f\"cor(A.G, B.G) = {np.corrcoef(gA, gB)[0,1]:+.3f}   target {rho_g}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "140f1c6e",
+   "metadata": {},
+   "source": [
+    "## 3. Splitting the direct genetic score into transmitted halves\n",
+    "\n",
+    "For indirect-effect work, we need to know which alleles a child got from\n",
+    "each parent. `haplotypeGenetic(eff, haplotype='maternal')` projects only\n",
+    "the maternal-side haplotype copy onto `eff` — and likewise for paternal.\n",
+    "Their sum is the diploid DGE.\n",
+    "\n",
+    "**One subtlety:** unlike `genetic(...)`, `haplotypeGenetic(...)` operates\n",
+    "on raw 0/1 haplotype dosages — no per-SNP standardization. To target a\n",
+    "heritability of `h²` we must rescale `β` by `1/sqrt(2p(1-p))` per SNP so\n",
+    "that `Σ 2p(1-p)·β² ≈ h²`. Otherwise variance comes out at `h²/2` for\n",
+    "uniform MAF=0.5."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c1441f57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:51.994745Z",
+     "iopub.status.busy": "2026-04-25T01:40:51.994650Z",
+     "iopub.status.idle": "2026-04-25T01:40:52.360208Z",
+     "shell.execute_reply": "2026-04-25T01:40:52.359889Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "var(TraitB.DGE)        = 0.515   target 0.5\n",
+      "var(TraitB.T_mat)      = 0.259   target 0.25\n",
+      "var(TraitB.T_pat)      = 0.254   target 0.25\n",
+      "cov(T_mat, T_pat)      = +0.001   target ~0\n",
+      "max|T_mat+T_pat - DGE| = 0.00e+00   must be ~0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get founder allele frequencies for the rescale\n",
+    "afs = np.asarray(founder_hap.variants.af, dtype=np.float64)\n",
+    "betas_raw = betas / np.sqrt(2 * afs * (1 - afs))[:, None]\n",
+    "\n",
+    "# Tell AdditiveEffects we're now in raw-dosage units\n",
+    "eff_A = AdditiveEffects.from_array(betas_raw[:, 0], standardized=False)\n",
+    "eff_B = AdditiveEffects.from_array(betas_raw[:, 1], standardized=False)\n",
+    "\n",
+    "arch = Architecture(formula=\"\"\"\n",
+    "TraitA.T_mat ~ haplotypeGenetic(eff_A, haplotype='maternal')\n",
+    "TraitA.T_pat ~ haplotypeGenetic(eff_A, haplotype='paternal')\n",
+    "TraitA.DGE   ~ TraitA.T_mat + TraitA.T_pat\n",
+    "TraitA.E     ~ noise({eA})\n",
+    "TraitA       ~ TraitA.DGE + TraitA.E\n",
+    "\n",
+    "TraitB.T_mat ~ haplotypeGenetic(eff_B, haplotype='maternal')\n",
+    "TraitB.T_pat ~ haplotypeGenetic(eff_B, haplotype='paternal')\n",
+    "TraitB.DGE   ~ TraitB.T_mat + TraitB.T_pat\n",
+    "TraitB.E     ~ noise({eB})\n",
+    "TraitB       ~ TraitB.DGE + TraitB.E\n",
+    "\"\"\".format(eA=1-h2_A, eB=1-h2_B),\n",
+    "    effects={\"eff_A\": eff_A, \"eff_B\": eff_B},\n",
+    ")\n",
+    "\n",
+    "sim = NSimulation(\n",
+    "    founder_haplotypes=founder_hap,\n",
+    "    architecture=arch,\n",
+    "    mating_regime=RandomMating(offspring_per_pair=2),\n",
+    "    recombination_map=RecombinationMap.constant_map(m=m, p=0.5),\n",
+    "    seed=3,\n",
+    ")\n",
+    "sim.run(2)\n",
+    "\n",
+    "ph = sim.phenotype_history[1]\n",
+    "recon = ph[\"TraitB.T_mat\"] + ph[\"TraitB.T_pat\"]\n",
+    "print(f\"var(TraitB.DGE)        = {ph['TraitB.DGE'].var():.3f}   target {h2_B}\")\n",
+    "print(f\"var(TraitB.T_mat)      = {ph['TraitB.T_mat'].var():.3f}   target {h2_B/2}\")\n",
+    "print(f\"var(TraitB.T_pat)      = {ph['TraitB.T_pat'].var():.3f}   target {h2_B/2}\")\n",
+    "print(f\"cov(T_mat, T_pat)      = {np.cov(ph['TraitB.T_mat'], ph['TraitB.T_pat'])[0,1]:+.3f}   target ~0\")\n",
+    "print(f\"max|T_mat+T_pat - DGE| = {np.abs(recon - ph['TraitB.DGE']).max():.2e}   must be ~0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62316deb",
+   "metadata": {},
+   "source": [
+    "The two transmitted-allele components are uncorrelated under\n",
+    "random mating (each haplotype is an independent meiotic draw) and sum\n",
+    "exactly to the diploid DGE. We're now ready to source the indirect\n",
+    "channel from non-transmitted alleles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36f23083",
+   "metadata": {},
+   "source": [
+    "## 4. Vertical (indirect genetic) transmission with T/NT separation\n",
+    "\n",
+    "The biological pathway for indirect genetic effects is\n",
+    "`parent_genome → parent_phenotype → child_environment → child_phenotype`.\n",
+    "The parent's *full* DGE drives the parent's phenotype, so the natural\n",
+    "input to the child's IGE channel is the parent's full DGE, not just the\n",
+    "non-transmitted half.\n",
+    "\n",
+    "But the **identification problem** is that half of the parent's DGE\n",
+    "*is* in the child's own genome (the transmitted alleles), which makes\n",
+    "the child's DGE and child's IGE positively correlated. The classical\n",
+    "NTC fix is to source identification — separately — from the\n",
+    "**non-transmitted** half: `NT = parental_DGE − transmitted`.\n",
+    "\n",
+    "So we wire two parental lookups:\n",
+    "\n",
+    "* **`mother(TraitB.DGE, normalize=False, founder=...)`** → raw parental\n",
+    "  DGE on the same scale as `TraitB.T_mat`. Subtraction gives `NT_m`\n",
+    "  exactly: `NT_m = PDGE_m − T_mat`. Used for downstream estimation.\n",
+    "* **`mother(TraitB.DGE, normalize=True, founder=...)`** → standardized\n",
+    "  parental DGE every generation. This feeds the IGE channel with\n",
+    "  `var(IGE) ≡ B_vIGE` regardless of drift or AM-induced variance shifts.\n",
+    "\n",
+    "Coefficients are `sqrt(B_vIGE · p_mom)` and `sqrt(B_vIGE · p_dad)`. Below\n",
+    "we set `p_mom = p_dad = 0.5` so each parent contributes half."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a0c3031f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:52.361274Z",
+     "iopub.status.busy": "2026-04-25T01:40:52.361178Z",
+     "iopub.status.idle": "2026-04-25T01:40:52.581463Z",
+     "shell.execute_reply": "2026-04-25T01:40:52.581151Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "var(TraitB.DGE)            = 0.511   target 0.5\n",
+      "var(TraitB.IGE)            = 0.402   target 0.4  (pinned)\n",
+      "var(TraitB.E)              = 0.096   target 0.09999999999999998\n",
+      "var(TraitB.NT_m)           = 0.262   target 0.25\n",
+      "max|PDGE_m - T_mat - NT_m| = 0.00e+00   must be ~0\n",
+      "cov(DGE, IGE)              = +0.323   theoretical ~+0.316\n",
+      "var(TraitB)                = 1.659   inflated by 2·cov(DGE, IGE) — see below\n"
+     ]
+    }
+   ],
+   "source": [
+    "B_vIGE = 0.4\n",
+    "p_mom, p_dad = 0.5, 0.5\n",
+    "\n",
+    "formula = \"\"\"\\\n",
+    "TraitB.T_mat ~ haplotypeGenetic(eff_B, haplotype='maternal')\n",
+    "TraitB.T_pat ~ haplotypeGenetic(eff_B, haplotype='paternal')\n",
+    "TraitB.DGE   ~ TraitB.T_mat + TraitB.T_pat\n",
+    "\n",
+    "# Raw parental DGE (lookup) — used for T/NT subtraction\n",
+    "TraitB.PDGE_m ~ mother(TraitB.DGE, normalize=False, founder=noise({h2B}))\n",
+    "TraitB.PDGE_f ~ father(TraitB.DGE, normalize=False, founder=noise({h2B}))\n",
+    "TraitB.NT_m   ~ TraitB.PDGE_m - TraitB.T_mat\n",
+    "TraitB.NT_f   ~ TraitB.PDGE_f - TraitB.T_pat\n",
+    "\n",
+    "# Variance-pinned IGE channel\n",
+    "TraitB.IGE_src_m ~ mother(TraitB.DGE, normalize=True, founder=noise(1.0))\n",
+    "TraitB.IGE_src_f ~ father(TraitB.DGE, normalize=True, founder=noise(1.0))\n",
+    "TraitB.IGE       ~ {c_m} * TraitB.IGE_src_m + {c_f} * TraitB.IGE_src_f\n",
+    "\n",
+    "TraitB.E ~ noise({eB})\n",
+    "TraitB   ~ TraitB.DGE + TraitB.IGE + TraitB.E\n",
+    "\"\"\".format(\n",
+    "    h2B=h2_B,\n",
+    "    c_m=np.sqrt(B_vIGE * p_mom),\n",
+    "    c_f=np.sqrt(B_vIGE * p_dad),\n",
+    "    eB=1 - h2_B - B_vIGE,\n",
+    ")\n",
+    "\n",
+    "arch = Architecture(formula=formula, effects={\"eff_B\": eff_B})\n",
+    "sim = NSimulation(\n",
+    "    founder_haplotypes=founder_hap,\n",
+    "    architecture=arch,\n",
+    "    mating_regime=RandomMating(offspring_per_pair=2),\n",
+    "    recombination_map=RecombinationMap.constant_map(m=m, p=0.5),\n",
+    "    seed=4,\n",
+    ")\n",
+    "sim.run(2)\n",
+    "\n",
+    "ph = sim.phenotype_history[1]\n",
+    "nt_recon = ph[\"TraitB.PDGE_m\"] - ph[\"TraitB.T_mat\"]\n",
+    "print(f\"var(TraitB.DGE)            = {ph['TraitB.DGE'].var():.3f}   target {h2_B}\")\n",
+    "print(f\"var(TraitB.IGE)            = {ph['TraitB.IGE'].var():.3f}   target {B_vIGE}  (pinned)\")\n",
+    "print(f\"var(TraitB.E)              = {ph['TraitB.E'].var():.3f}   target {1-h2_B-B_vIGE}\")\n",
+    "print(f\"var(TraitB.NT_m)           = {ph['TraitB.NT_m'].var():.3f}   target {h2_B/2}\")\n",
+    "print(f\"max|PDGE_m - T_mat - NT_m| = {np.abs(nt_recon - ph['TraitB.NT_m']).max():.2e}   must be ~0\")\n",
+    "cov_dge_ige = np.cov(ph[\"TraitB.DGE\"], ph[\"TraitB.IGE\"])[0, 1]\n",
+    "print(f\"cov(DGE, IGE)              = {cov_dge_ige:+.3f}   theoretical ~{(0.5*h2_B*B_vIGE)**0.5:+.3f}\")\n",
+    "print(f\"var(TraitB)                = {ph['TraitB'].var():.3f}   inflated by 2·cov(DGE, IGE) — see below\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b5e5619",
+   "metadata": {},
+   "source": [
+    "The total `var(TraitB)` is genuinely above 1 — that's the\n",
+    "biological DGE↔IGE confound at work. Without the T/NT split it would be\n",
+    "unrecoverable. With it, we can identify the indirect channel cleanly,\n",
+    "which is the next section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66333472",
+   "metadata": {},
+   "source": [
+    "## 5. Estimating direct and indirect coefficients\n",
+    "\n",
+    "Under the model in §4:\n",
+    "\n",
+    "```\n",
+    "child_TraitB = (T_mat + T_pat)\n",
+    "             + α_m · (T_mat + NT_m)           # IGE_src_m ≈ (T_mat + NT_m) up to scale\n",
+    "             + α_f · (T_pat + NT_f)\n",
+    "             + E\n",
+    "           = T_mat·(1+α_m) + T_pat·(1+α_f) + α_m·NT_m + α_f·NT_f + E\n",
+    "```\n",
+    "\n",
+    "where `α_m ≈ sqrt(B_vIGE · p_mom / var(parental_DGE))` is the realized\n",
+    "coefficient on the parent's *raw* DGE in the IGE channel after the\n",
+    "internal normalize-by-SD step. So an OLS regression of child phenotype\n",
+    "on the four columns recovers:\n",
+    "\n",
+    "* `β(T_mat) = 1 + α_m`,  `β(T_pat) = 1 + α_f`\n",
+    "* `β(NT_m) = α_m`,        `β(NT_f) = α_f`\n",
+    "\n",
+    "Subtracting the NT coefficient from the matching T coefficient yields\n",
+    "the **direct effect of one allele's worth of polygenic score on the\n",
+    "child's phenotype** (~1 by construction — we built the model so that a\n",
+    "unit of parental DGE adds a unit to child DGE, plus its IGE pathway).\n",
+    "\n",
+    "We re-run the §4 model at a larger sample size for tight estimates, then\n",
+    "fit the regression."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "de17965c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:52.582416Z",
+     "iopub.status.busy": "2026-04-25T01:40:52.582318Z",
+     "iopub.status.idle": "2026-04-25T01:40:53.443060Z",
+     "shell.execute_reply": "2026-04-25T01:40:53.442679Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>estimate</th>\n",
+       "      <th>std_error</th>\n",
+       "      <th>t_value</th>\n",
+       "      <th>p_value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>intercept</th>\n",
+       "      <td>1.278768</td>\n",
+       "      <td>0.005012</td>\n",
+       "      <td>255.161833</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>T_mat</th>\n",
+       "      <td>1.631614</td>\n",
+       "      <td>0.004459</td>\n",
+       "      <td>365.940428</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>T_pat</th>\n",
+       "      <td>1.637219</td>\n",
+       "      <td>0.004441</td>\n",
+       "      <td>368.636537</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NT_m</th>\n",
+       "      <td>0.634530</td>\n",
+       "      <td>0.004511</td>\n",
+       "      <td>140.652121</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NT_f</th>\n",
+       "      <td>0.620610</td>\n",
+       "      <td>0.004475</td>\n",
+       "      <td>138.679488</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           estimate  std_error     t_value  p_value\n",
+       "intercept  1.278768   0.005012  255.161833      0.0\n",
+       "T_mat      1.631614   0.004459  365.940428      0.0\n",
+       "T_pat      1.637219   0.004441  368.636537      0.0\n",
+       "NT_m       0.634530   0.004511  140.652121      0.0\n",
+       "NT_f       0.620610   0.004475  138.679488      0.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Re-run with a bigger n for precision\n",
+    "np.random.seed(10)\n",
+    "n_fam_big = 10_000\n",
+    "m_big     = 2_000\n",
+    "\n",
+    "founder_big = founder_haplotypes_uniform_AFs(n=2 * n_fam_big, m=m_big)\n",
+    "afs_big = np.asarray(founder_big.variants.af, dtype=np.float64)\n",
+    "\n",
+    "beta_big = draw_bivariate_betas(h2_A, h2_B, rho_g, m=m_big, seed=11)\n",
+    "beta_big_raw = beta_big / np.sqrt(2 * afs_big * (1 - afs_big))[:, None]\n",
+    "eff_B_big = AdditiveEffects.from_array(beta_big_raw[:, 1], standardized=False)\n",
+    "\n",
+    "arch_big = Architecture(formula=formula, effects={\"eff_B\": eff_B_big})\n",
+    "sim_big = NSimulation(\n",
+    "    founder_haplotypes=founder_big,\n",
+    "    architecture=arch_big,\n",
+    "    mating_regime=RandomMating(offspring_per_pair=2),\n",
+    "    recombination_map=RecombinationMap.constant_map(m=m_big, p=0.5),\n",
+    "    seed=12,\n",
+    ")\n",
+    "sim_big.run(2)\n",
+    "ph = sim_big.phenotype_history[1]\n",
+    "\n",
+    "# Build design matrix\n",
+    "X = np.column_stack([\n",
+    "    ph[\"TraitB.T_mat\"], ph[\"TraitB.T_pat\"],\n",
+    "    ph[\"TraitB.NT_m\"],  ph[\"TraitB.NT_f\"],\n",
+    "])\n",
+    "y = ph[\"TraitB\"]\n",
+    "ols = sm.OLS(y, sm.add_constant(X)).fit()\n",
+    "\n",
+    "names = [\"intercept\", \"T_mat\", \"T_pat\", \"NT_m\", \"NT_f\"]\n",
+    "out = pd.DataFrame({\n",
+    "    \"estimate\":   ols.params,\n",
+    "    \"std_error\":  ols.bse,\n",
+    "    \"t_value\":    ols.tvalues,\n",
+    "    \"p_value\":    ols.pvalues,\n",
+    "}, index=names)\n",
+    "out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64b2042a",
+   "metadata": {},
+   "source": [
+    "Compare against the theoretical targets. We seeded the IGE\n",
+    "channel with coefficient `sqrt(B_vIGE · p_parent)` on a *standardized*\n",
+    "parental DGE, so the realized coefficient on the raw parental DGE is\n",
+    "`α = sqrt(B_vIGE · p_parent / var(parental_DGE))`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "dc9d1f56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:53.444045Z",
+     "iopub.status.busy": "2026-04-25T01:40:53.443944Z",
+     "iopub.status.idle": "2026-04-25T01:40:53.449120Z",
+     "shell.execute_reply": "2026-04-25T01:40:53.448860Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>theoretical</th>\n",
+       "      <th>estimate</th>\n",
+       "      <th>error</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>intercept</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.278768</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>T_mat</th>\n",
+       "      <td>1.630436</td>\n",
+       "      <td>1.631614</td>\n",
+       "      <td>0.001178</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>T_pat</th>\n",
+       "      <td>1.630436</td>\n",
+       "      <td>1.637219</td>\n",
+       "      <td>0.006783</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NT_m</th>\n",
+       "      <td>0.630436</td>\n",
+       "      <td>0.634530</td>\n",
+       "      <td>0.004094</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>NT_f</th>\n",
+       "      <td>0.630436</td>\n",
+       "      <td>0.620610</td>\n",
+       "      <td>-0.009827</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           theoretical  estimate     error\n",
+       "intercept          NaN  1.278768       NaN\n",
+       "T_mat         1.630436  1.631614  0.001178\n",
+       "T_pat         1.630436  1.637219  0.006783\n",
+       "NT_m          0.630436  0.634530  0.004094\n",
+       "NT_f          0.630436  0.620610 -0.009827"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parent_dge_var = sim_big.phenotype_history[0][\"TraitB.DGE\"].var()\n",
+    "alpha_m = np.sqrt(B_vIGE * p_mom / parent_dge_var)\n",
+    "alpha_f = np.sqrt(B_vIGE * p_dad / parent_dge_var)\n",
+    "\n",
+    "theory = pd.DataFrame({\n",
+    "    \"theoretical\": [np.nan, 1 + alpha_m, 1 + alpha_f, alpha_m, alpha_f],\n",
+    "    \"estimate\":    ols.params,\n",
+    "}, index=names)\n",
+    "theory[\"error\"] = theory.estimate - theory.theoretical\n",
+    "theory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9669c711",
+   "metadata": {},
+   "source": [
+    "**Direct effect** (per allele unit of polygenic score) is recovered as\n",
+    "`β(T_mat) − β(NT_m)` and `β(T_pat) − β(NT_f)`, both of which should sit\n",
+    "at `1.0`. **Indirect effect** is `β(NT_m)` and `β(NT_f)`, which match\n",
+    "`α_m` and `α_f` directly.\n",
+    "\n",
+    "Notice that the simple regression of child phenotype on its own DGE\n",
+    "*without* NT controls would over-attribute the indirect channel to the\n",
+    "direct channel — the classical \"dynastic confound.\" Throw it in for\n",
+    "contrast:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4ada6f84",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:53.449874Z",
+     "iopub.status.busy": "2026-04-25T01:40:53.449783Z",
+     "iopub.status.idle": "2026-04-25T01:40:53.466782Z",
+     "shell.execute_reply": "2026-04-25T01:40:53.466508Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "naive direct estimate = 1.641  (should be ~1.630, conflating direct + indirect)\n"
+     ]
+    }
+   ],
+   "source": [
+    "contam = sm.OLS(y, sm.add_constant(ph[\"TraitB.DGE\"])).fit()\n",
+    "print(f\"naive direct estimate = {contam.params[1]:.3f}  \"\n",
+    "      f\"(should be ~{1 + alpha_m:.3f}, conflating direct + indirect)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d39ea597",
+   "metadata": {},
+   "source": [
+    "## 6. Layering on assortative mating\n",
+    "\n",
+    "`xftsim.nmate.LinearAssortativeMating` rank-pairs each sex on a\n",
+    "phenotypic composite (sum of standardized components from\n",
+    "`component_names`). The `r` argument is the **target per-cell exchangeable\n",
+    "cross-mate correlation** under K traits.\n",
+    "\n",
+    "* **K = 1**: the spousal correlation on that single trait is `≈ r`.\n",
+    "* **K > 1**: every (parent1_t_i, parent2_t_j) cell — both diagonal\n",
+    "  (per-trait) and off-diagonal (cross-trait) — is targeted at `r`.\n",
+    "  Feasibility bound is `|r| ≤ 1/K`. Beyond that the latent score\n",
+    "  correlation `R = K·r` saturates and you get less assortment than you\n",
+    "  asked for.\n",
+    "\n",
+    "The current implementation **warns** at construction when `|r| > 1/K`,\n",
+    "and again at runtime when the realized `R` exceeds 1. Below: each of the\n",
+    "three regimes, side by side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "eb9b7faf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T01:40:53.467626Z",
+     "iopub.status.busy": "2026-04-25T01:40:53.467455Z",
+     "iopub.status.idle": "2026-04-25T01:40:56.157476Z",
+     "shell.execute_reply": "2026-04-25T01:40:56.156992Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "random                              cor(A,A)=+0.012  cor(B,B)=-0.012  cor(A,B)=-0.007  cor(B,A)=+0.014\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "single-trait r=0.3 on TraitA        cor(A,A)=+0.296  cor(B,B)=-0.016  cor(A,B)=+0.000  cor(B,A)=+0.010\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cross-trait r=0.3 (K=2, feasible)   cor(A,A)=+0.304  cor(B,B)=+0.306  cor(A,B)=+0.290  cor(B,A)=+0.297\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cross-trait r=0.75 (K=2, INFEASIBLE) cor(A,A)=+0.504  cor(B,B)=+0.504  cor(A,B)=+0.515  cor(B,A)=+0.500\n",
+      "  warn: LinearAssortativeMating: |r|=0.75 exceeds 1/K=0.5 for K=2 traits. Under uncorrelated within-person traits this target is…\n",
+      "  warn: LinearAssortativeMating: realized latent score correlation R=1.48 exceeds 1 for r=0.75, K=2. Clamping to 0.999 (assortme…\n"
+     ]
+    }
+   ],
+   "source": [
+    "from xftsim.nmate import LinearAssortativeMating\n",
+    "import warnings\n",
+    "\n",
+    "def run_am(mating, label):\n",
+    "    sim = NSimulation(\n",
+    "        founder_haplotypes=founder_haplotypes_uniform_AFs(n=2*n_fam, m=m),\n",
+    "        architecture=Architecture(\n",
+    "            formula=\"\"\"\\\n",
+    "TraitA.G ~ genetic(eff_A)\n",
+    "TraitA.E ~ noise({eA})\n",
+    "TraitA   ~ TraitA.G + TraitA.E\n",
+    "TraitB.G ~ genetic(eff_B)\n",
+    "TraitB.E ~ noise({eB})\n",
+    "TraitB   ~ TraitB.G + TraitB.E\n",
+    "\"\"\".format(eA=1-h2_A, eB=1-h2_B),\n",
+    "            effects={\"eff_A\": AdditiveEffects.from_h2(h2_A, m=m, seed=21),\n",
+    "                     \"eff_B\": AdditiveEffects.from_h2(h2_B, m=m, seed=22)},\n",
+    "        ),\n",
+    "        mating_regime=mating,\n",
+    "        recombination_map=RecombinationMap.constant_map(m=m, p=0.5),\n",
+    "        seed=30,\n",
+    "    )\n",
+    "    sim.run(2)\n",
+    "    ph = sim.phenotype_history[1]\n",
+    "    ped = sim.pedigree_history[1]\n",
+    "    par = sim.phenotype_history[0]\n",
+    "    moms = par[\"TraitA\"][ped.maternal_idx], par[\"TraitB\"][ped.maternal_idx]\n",
+    "    dads = par[\"TraitA\"][ped.paternal_idx], par[\"TraitB\"][ped.paternal_idx]\n",
+    "    rAA = np.corrcoef(moms[0], dads[0])[0, 1]\n",
+    "    rBB = np.corrcoef(moms[1], dads[1])[0, 1]\n",
+    "    rAB = np.corrcoef(moms[0], dads[1])[0, 1]\n",
+    "    rBA = np.corrcoef(moms[1], dads[0])[0, 1]\n",
+    "    print(f\"{label:35s} cor(A,A)={rAA:+.3f}  cor(B,B)={rBB:+.3f}  \"\n",
+    "          f\"cor(A,B)={rAB:+.3f}  cor(B,A)={rBA:+.3f}\")\n",
+    "\n",
+    "# 1) random mating — baseline\n",
+    "run_am(RandomMating(offspring_per_pair=2),\n",
+    "       \"random\")\n",
+    "\n",
+    "# 2) single-trait AM on TraitA\n",
+    "run_am(LinearAssortativeMating(component_names=[\"TraitA\"], r=0.3,\n",
+    "                                offspring_per_pair=2),\n",
+    "       \"single-trait r=0.3 on TraitA\")\n",
+    "\n",
+    "# 3) cross-trait AM — feasible (|r| <= 1/K = 0.5)\n",
+    "run_am(LinearAssortativeMating(component_names=[\"TraitA\", \"TraitB\"], r=0.3,\n",
+    "                                offspring_per_pair=2),\n",
+    "       \"cross-trait r=0.3 (K=2, feasible)\")\n",
+    "\n",
+    "# 4) cross-trait AM — infeasible: should warn at construction AND at runtime\n",
+    "with warnings.catch_warnings(record=True) as caught:\n",
+    "    warnings.simplefilter(\"always\")\n",
+    "    run_am(LinearAssortativeMating(component_names=[\"TraitA\", \"TraitB\"], r=0.75,\n",
+    "                                    offspring_per_pair=2),\n",
+    "           \"cross-trait r=0.75 (K=2, INFEASIBLE)\")\n",
+    "    for w in caught:\n",
+    "        if \"LinearAssortativeMating\" in str(w.message):\n",
+    "            print(f\"  warn: {str(w.message)[:120]}…\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27dfab0c",
+   "metadata": {},
+   "source": [
+    "**Reading the matrix:** under exchangeable cross-trait AM with\n",
+    "`r = 0.3` you'd want all four (A,A), (B,B), (A,B), (B,A) parental\n",
+    "correlations close to 0.3. With `r = 0.75` they all top out around 0.5\n",
+    "because the latent score correlation got clamped at saturation.\n",
+    "\n",
+    "**Putting it all together:** to reproduce a study of indirect genetic\n",
+    "effects under assortment, swap §6's mating regime into §4's architecture\n",
+    "and re-run §5's NTC regression. Under AM, `var(parent_DGE)` inflates each\n",
+    "generation, so `α_m`, `α_f` will drift from their gen-0 values — but\n",
+    "they remain identifiable from the OLS fit, generation by generation."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/08_direct_indirect_effects.ipynb
+++ b/docs/examples/08_direct_indirect_effects.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e5876605",
+   "id": "87a9f50a",
    "metadata": {},
    "source": [
     "# Direct vs Indirect Genetic Effects in `xftsim`\n",
@@ -11,7 +11,7 @@
     "\n",
     "1. Install the `ap_indirect` development branch.\n",
     "2. Build family-based simulations of increasing complexity using the new\n",
-    "   formula DSL — DGE-only, two correlated traits, per-haplotype\n",
+    "   formula DSL: DGE-only, two correlated traits, per-haplotype\n",
     "   transmitted scores, vertical (indirect) transmission with a\n",
     "   variance-pinned IGE channel.\n",
     "3. Verify each stage's variance / covariance / identity targets.\n",
@@ -21,25 +21,25 @@
     "   see what happens when the per-cell exchangeable correlation becomes\n",
     "   infeasible.\n",
     "\n",
-    "The architecture decisions made here (sourcing IGE from the parent's\n",
+    "The architecture decisions made here -- sourcing IGE from the parent's\n",
     "*full* DGE for biological realism while separately tracking the\n",
-    "non-transmitted parental allele score for clean identification) are\n",
+    "non-transmitted parental allele score for clean identification -- are\n",
     "explained inline as we build the formula up."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4087a5d4",
+   "id": "e8c469eb",
    "metadata": {},
    "source": [
     "## 0. Installation\n",
     "\n",
-    "The `ap_indirect` branch is on top of the `ajay` rewrite — numpy-backed\n",
+    "The `ap_indirect` branch sits on top of the `ajay` rewrite: numpy-backed\n",
     "data structures, a formula DSL for architectures, and a new simulation\n",
     "loop. None of the legacy xarray-based components are needed for the\n",
     "work in this notebook.\n",
     "\n",
-    "### Option A — clone and use the dev script\n",
+    "### Option A -- clone and use the dev script\n",
     "\n",
     "```bash\n",
     "git clone -b ap_indirect https://github.com/border-lab/xftsim.git\n",
@@ -48,14 +48,14 @@
     "source .venv/bin/activate\n",
     "```\n",
     "\n",
-    "### Option B — pip install directly into an existing env\n",
+    "### Option B -- pip install directly into an existing env\n",
     "\n",
     "```bash\n",
     "pip install \"git+https://github.com/border-lab/xftsim.git@ap_indirect#egg=xftsim[legacy,dev]\"\n",
     "```\n",
     "\n",
     "The `[legacy]` extra pulls in `sgkit` (only needed if you load real zarr\n",
-    "genomes — not used here). `[dev]` pulls in pytest etc.\n",
+    "genomes -- not used here). `[dev]` pulls in pytest etc.\n",
     "\n",
     "### Smoke check"
    ]
@@ -63,13 +63,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "76ac340b",
+   "id": "402eb473",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:48.952292Z",
-     "iopub.status.busy": "2026-04-25T01:40:48.952226Z",
-     "iopub.status.idle": "2026-04-25T01:40:50.867262Z",
-     "shell.execute_reply": "2026-04-25T01:40:50.866766Z"
+     "iopub.execute_input": "2026-04-25T01:51:49.289065Z",
+     "iopub.status.busy": "2026-04-25T01:51:49.289009Z",
+     "iopub.status.idle": "2026-04-25T01:51:51.203199Z",
+     "shell.execute_reply": "2026-04-25T01:51:51.202686Z"
     }
    },
    "outputs": [
@@ -77,7 +77,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "xftsim: 0.3.0.dev110\n",
+      "xftsim: 0.3.0.dev111\n",
       "numpy:  1.26.4\n"
      ]
     }
@@ -94,10 +94,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e567c86",
+   "id": "18942637",
    "metadata": {},
    "source": [
-    "## 1. The smallest useful simulation — single trait, DGE + E\n",
+    "## 1. The smallest useful simulation -- single trait, DGE + E\n",
     "\n",
     "Every architecture is a string in the formula DSL plus an `effects` dict.\n",
     "The simplest possible model is one trait with a direct genetic component\n",
@@ -113,20 +113,20 @@
     "phenotype dict, so the variance partition is recoverable by name. `Y` is\n",
     "just an arithmetic aggregation node.\n",
     "\n",
-    "For uniform-AF founders with MAF drawn from `U(0.1, 0.9)`, picking\n",
-    "`var_E = 1 - h²` makes `var(Y) ≈ 1`."
+    "For uniform-AF founders with MAF drawn from $U(0.1, 0.9)$, picking\n",
+    "$\\mathrm{var}(E) = 1 - h^2$ makes $\\mathrm{var}(Y) \\approx 1$."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "56e7de7e",
+   "id": "40557227",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:50.868341Z",
-     "iopub.status.busy": "2026-04-25T01:40:50.868073Z",
-     "iopub.status.idle": "2026-04-25T01:40:51.308578Z",
-     "shell.execute_reply": "2026-04-25T01:40:51.308049Z"
+     "iopub.execute_input": "2026-04-25T01:51:51.204367Z",
+     "iopub.status.busy": "2026-04-25T01:51:51.204096Z",
+     "iopub.status.idle": "2026-04-25T01:51:51.631458Z",
+     "shell.execute_reply": "2026-04-25T01:51:51.630547Z"
     }
    },
    "outputs": [
@@ -136,7 +136,7 @@
      "text": [
       "var(Y.G) = 0.516   target 0.5\n",
       "var(Y.E) = 0.514   target 0.5\n",
-      "var(Y)   = 1.040     target ~1\n"
+      "var(Y)   = 1.062     target ~1\n"
      ]
     }
    ],
@@ -182,48 +182,53 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79427ec7",
+   "id": "319498c7",
    "metadata": {},
    "source": [
-    "**`genetic(eff)`** uses `standardized_matvec` internally — it\n",
+    "**`genetic(eff)`** uses `standardized_matvec` internally: it\n",
     "centers and scales each column to unit variance under HWE before\n",
-    "multiplying by the per-allele effects. So `AdditiveEffects.from_h2(h2=...,\n",
-    "m=...)` draws `β ~ N(0, h²/m)` and the resulting genetic value variance\n",
-    "hits `h²` directly. Good for quick experiments.\n",
+    "multiplying by the per-allele effects. So\n",
+    "`AdditiveEffects.from_h2(h2=..., m=...)` draws\n",
+    "$\\beta \\sim \\mathcal{N}(0, h^2/m)$ and the resulting genetic-value\n",
+    "variance hits $h^2$ directly. Good for quick experiments.\n",
     "\n",
-    "We'll switch to the **raw-dosage** path (`haplotypeGenetic`) in §3 — it\n",
-    "gives us per-haplotype scores but at the cost of having to rescale\n",
-    "`β` by `1/sqrt(2p(1-p))` ourselves."
+    "We'll switch to the **raw-dosage** path (`haplotypeGenetic`) in $\\S 3$:\n",
+    "it gives us per-haplotype scores but at the cost of having to rescale\n",
+    "$\\beta$ by $1/\\sqrt{2 p (1-p)}$ ourselves."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a678c85b",
+   "id": "643bb68f",
    "metadata": {},
    "source": [
     "## 2. Two traits with correlated direct effects\n",
     "\n",
-    "To put a target genetic correlation `ρ_g` between the two traits, draw\n",
-    "the per-SNP `β` matrix from a bivariate normal with off-diagonal\n",
-    "correlation `ρ_g`:\n",
+    "To put a target genetic correlation $\\rho_g$ between two traits, draw\n",
+    "the per-SNP $\\beta$ matrix from a bivariate normal with off-diagonal\n",
+    "correlation $\\rho_g$:\n",
     "\n",
-    "`β ~ N(0, Σ/m)` with `Σ = [[h²_A, ρ_g·sqrt(h²_A·h²_B)], [ρ_g·sqrt(h²_A·h²_B), h²_B]]`\n",
+    "$$\n",
+    "\\beta \\sim \\mathcal{N}(0, \\Sigma/m), \\qquad\n",
+    "\\Sigma = \\begin{bmatrix} h_A^2 & \\rho_g \\sqrt{h_A^2 h_B^2} \\\\\n",
+    "                         \\rho_g \\sqrt{h_A^2 h_B^2} & h_B^2 \\end{bmatrix}.\n",
+    "$$\n",
     "\n",
     "Then register one `AdditiveEffects` per column. The per-trait\n",
-    "heritabilities still hit `h²_A` and `h²_B`, and the cross-trait DGE\n",
+    "heritabilities still hit $h_A^2$ and $h_B^2$, and the cross-trait DGE\n",
     "covariance carries through."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8bc98754",
+   "id": "b63905d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:51.309696Z",
-     "iopub.status.busy": "2026-04-25T01:40:51.309577Z",
-     "iopub.status.idle": "2026-04-25T01:40:51.993539Z",
-     "shell.execute_reply": "2026-04-25T01:40:51.993174Z"
+     "iopub.execute_input": "2026-04-25T01:51:51.632740Z",
+     "iopub.status.busy": "2026-04-25T01:51:51.632632Z",
+     "iopub.status.idle": "2026-04-25T01:51:52.317458Z",
+     "shell.execute_reply": "2026-04-25T01:51:52.317019Z"
     }
    },
    "outputs": [
@@ -231,9 +236,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "var(TraitA.G) = 0.515   target 0.5\n",
-      "var(TraitB.G) = 0.511   target 0.5\n",
-      "cor(A.G, B.G) = +0.317   target 0.3\n"
+      "var(TraitA.G) = 0.506   target 0.5\n",
+      "var(TraitB.G) = 0.516   target 0.5\n",
+      "cor(A.G, B.G) = +0.316   target 0.3\n"
      ]
     }
    ],
@@ -241,7 +246,7 @@
     "def draw_bivariate_betas(h2_A, h2_B, rho_g, m, seed):\n",
     "    rng = np.random.default_rng(seed)\n",
     "    Sigma = np.array([\n",
-    "        [h2_A,                      rho_g * np.sqrt(h2_A * h2_B)],\n",
+    "        [h2_A,                       rho_g * np.sqrt(h2_A * h2_B)],\n",
     "        [rho_g * np.sqrt(h2_A*h2_B), h2_B],\n",
     "    ]) / m\n",
     "    return rng.multivariate_normal(mean=[0.0, 0.0], cov=Sigma, size=m)\n",
@@ -283,33 +288,34 @@
   },
   {
    "cell_type": "markdown",
-   "id": "140f1c6e",
+   "id": "b69576b5",
    "metadata": {},
    "source": [
     "## 3. Splitting the direct genetic score into transmitted halves\n",
     "\n",
     "For indirect-effect work, we need to know which alleles a child got from\n",
     "each parent. `haplotypeGenetic(eff, haplotype='maternal')` projects only\n",
-    "the maternal-side haplotype copy onto `eff` — and likewise for paternal.\n",
+    "the maternal-side haplotype copy onto `eff`, and likewise for paternal.\n",
     "Their sum is the diploid DGE.\n",
     "\n",
     "**One subtlety:** unlike `genetic(...)`, `haplotypeGenetic(...)` operates\n",
-    "on raw 0/1 haplotype dosages — no per-SNP standardization. To target a\n",
-    "heritability of `h²` we must rescale `β` by `1/sqrt(2p(1-p))` per SNP so\n",
-    "that `Σ 2p(1-p)·β² ≈ h²`. Otherwise variance comes out at `h²/2` for\n",
-    "uniform MAF=0.5."
+    "on raw $\\{0,1\\}$ haplotype dosages -- no per-SNP standardization. To\n",
+    "target a heritability of $h^2$ we must rescale $\\beta$ by\n",
+    "$1/\\sqrt{2 p (1-p)}$ per SNP so that $\\sum_j 2 p_j (1-p_j)\\, \\beta_j^2\n",
+    "\\approx h^2$. Otherwise variance comes out at $h^2/2$ for uniform\n",
+    "$\\mathrm{MAF} = 0.5$."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c1441f57",
+   "id": "5778f659",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:51.994745Z",
-     "iopub.status.busy": "2026-04-25T01:40:51.994650Z",
-     "iopub.status.idle": "2026-04-25T01:40:52.360208Z",
-     "shell.execute_reply": "2026-04-25T01:40:52.359889Z"
+     "iopub.execute_input": "2026-04-25T01:51:52.318562Z",
+     "iopub.status.busy": "2026-04-25T01:51:52.318451Z",
+     "iopub.status.idle": "2026-04-25T01:51:52.704213Z",
+     "shell.execute_reply": "2026-04-25T01:51:52.703733Z"
     }
    },
    "outputs": [
@@ -317,9 +323,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "var(TraitB.DGE)        = 0.515   target 0.5\n",
-      "var(TraitB.T_mat)      = 0.259   target 0.25\n",
-      "var(TraitB.T_pat)      = 0.254   target 0.25\n",
+      "var(TraitB.DGE)        = 0.502   target 0.5\n",
+      "var(TraitB.T_mat)      = 0.253   target 0.25\n",
+      "var(TraitB.T_pat)      = 0.247   target 0.25\n",
       "cov(T_mat, T_pat)      = +0.001   target ~0\n",
       "max|T_mat+T_pat - DGE| = 0.00e+00   must be ~0\n"
      ]
@@ -370,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62316deb",
+   "id": "a9638a4e",
    "metadata": {},
    "source": [
     "The two transmitted-allele components are uncorrelated under\n",
@@ -381,13 +387,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36f23083",
+   "id": "2a61bac5",
    "metadata": {},
    "source": [
     "## 4. Vertical (indirect genetic) transmission with T/NT separation\n",
     "\n",
     "The biological pathway for indirect genetic effects is\n",
-    "`parent_genome → parent_phenotype → child_environment → child_phenotype`.\n",
+    "\n",
+    "$$\n",
+    "\\text{parent genome} \\to \\text{parent phenotype}\n",
+    "\\to \\text{child environment} \\to \\text{child phenotype}.\n",
+    "$$\n",
+    "\n",
     "The parent's *full* DGE drives the parent's phenotype, so the natural\n",
     "input to the child's IGE channel is the parent's full DGE, not just the\n",
     "non-transmitted half.\n",
@@ -395,32 +406,35 @@
     "But the **identification problem** is that half of the parent's DGE\n",
     "*is* in the child's own genome (the transmitted alleles), which makes\n",
     "the child's DGE and child's IGE positively correlated. The classical\n",
-    "NTC fix is to source identification — separately — from the\n",
-    "**non-transmitted** half: `NT = parental_DGE − transmitted`.\n",
+    "NTC fix is to source identification -- separately -- from the\n",
+    "**non-transmitted** half: $\\mathrm{NT} = \\mathrm{PDGE} - T$.\n",
     "\n",
     "So we wire two parental lookups:\n",
     "\n",
-    "* **`mother(TraitB.DGE, normalize=False, founder=...)`** → raw parental\n",
-    "  DGE on the same scale as `TraitB.T_mat`. Subtraction gives `NT_m`\n",
-    "  exactly: `NT_m = PDGE_m − T_mat`. Used for downstream estimation.\n",
-    "* **`mother(TraitB.DGE, normalize=True, founder=...)`** → standardized\n",
+    "* **`mother(TraitB.DGE, normalize=False, founder=...)`** $\\to$ raw\n",
+    "  parental DGE on the same scale as `TraitB.T_mat`. Subtraction gives\n",
+    "  $\\mathrm{NT}_m$ exactly: $\\mathrm{NT}_m = \\mathrm{PDGE}_m - T_{\\text{mat}}$.\n",
+    "  Used for downstream estimation.\n",
+    "* **`mother(TraitB.DGE, normalize=True, founder=...)`** $\\to$ standardized\n",
     "  parental DGE every generation. This feeds the IGE channel with\n",
-    "  `var(IGE) ≡ B_vIGE` regardless of drift or AM-induced variance shifts.\n",
+    "  $\\mathrm{var}(\\mathrm{IGE}) \\equiv B_{\\text{vIGE}}$ regardless of drift\n",
+    "  or AM-induced variance shifts.\n",
     "\n",
-    "Coefficients are `sqrt(B_vIGE · p_mom)` and `sqrt(B_vIGE · p_dad)`. Below\n",
-    "we set `p_mom = p_dad = 0.5` so each parent contributes half."
+    "Coefficients are $\\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{mom}}}$ and\n",
+    "$\\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{dad}}}$. Below we set\n",
+    "$p_{\\text{mom}} = p_{\\text{dad}} = 0.5$ so each parent contributes half."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "a0c3031f",
+   "id": "4c4ba9a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:52.361274Z",
-     "iopub.status.busy": "2026-04-25T01:40:52.361178Z",
-     "iopub.status.idle": "2026-04-25T01:40:52.581463Z",
-     "shell.execute_reply": "2026-04-25T01:40:52.581151Z"
+     "iopub.execute_input": "2026-04-25T01:51:52.705689Z",
+     "iopub.status.busy": "2026-04-25T01:51:52.705558Z",
+     "iopub.status.idle": "2026-04-25T01:51:52.924990Z",
+     "shell.execute_reply": "2026-04-25T01:51:52.924636Z"
     }
    },
    "outputs": [
@@ -428,13 +442,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "var(TraitB.DGE)            = 0.511   target 0.5\n",
+      "var(TraitB.DGE)            = 0.522   target 0.5\n",
       "var(TraitB.IGE)            = 0.402   target 0.4  (pinned)\n",
-      "var(TraitB.E)              = 0.096   target 0.09999999999999998\n",
-      "var(TraitB.NT_m)           = 0.262   target 0.25\n",
+      "var(TraitB.E)              = 0.096   target 0.100\n",
+      "var(TraitB.NT_m)           = 0.253   target 0.25\n",
       "max|PDGE_m - T_mat - NT_m| = 0.00e+00   must be ~0\n",
-      "cov(DGE, IGE)              = +0.323   theoretical ~+0.316\n",
-      "var(TraitB)                = 1.659   inflated by 2·cov(DGE, IGE) — see below\n"
+      "cov(DGE, IGE)              = +0.327   theoretical ~+0.316\n",
+      "var(TraitB)                = 1.686   inflated by 2*cov(DGE,IGE)\n"
      ]
     }
    ],
@@ -447,7 +461,7 @@
     "TraitB.T_pat ~ haplotypeGenetic(eff_B, haplotype='paternal')\n",
     "TraitB.DGE   ~ TraitB.T_mat + TraitB.T_pat\n",
     "\n",
-    "# Raw parental DGE (lookup) — used for T/NT subtraction\n",
+    "# Raw parental DGE (lookup) -- used for T/NT subtraction\n",
     "TraitB.PDGE_m ~ mother(TraitB.DGE, normalize=False, founder=noise({h2B}))\n",
     "TraitB.PDGE_f ~ father(TraitB.DGE, normalize=False, founder=noise({h2B}))\n",
     "TraitB.NT_m   ~ TraitB.PDGE_m - TraitB.T_mat\n",
@@ -481,69 +495,84 @@
     "nt_recon = ph[\"TraitB.PDGE_m\"] - ph[\"TraitB.T_mat\"]\n",
     "print(f\"var(TraitB.DGE)            = {ph['TraitB.DGE'].var():.3f}   target {h2_B}\")\n",
     "print(f\"var(TraitB.IGE)            = {ph['TraitB.IGE'].var():.3f}   target {B_vIGE}  (pinned)\")\n",
-    "print(f\"var(TraitB.E)              = {ph['TraitB.E'].var():.3f}   target {1-h2_B-B_vIGE}\")\n",
+    "print(f\"var(TraitB.E)              = {ph['TraitB.E'].var():.3f}   target {1-h2_B-B_vIGE:.3f}\")\n",
     "print(f\"var(TraitB.NT_m)           = {ph['TraitB.NT_m'].var():.3f}   target {h2_B/2}\")\n",
     "print(f\"max|PDGE_m - T_mat - NT_m| = {np.abs(nt_recon - ph['TraitB.NT_m']).max():.2e}   must be ~0\")\n",
     "cov_dge_ige = np.cov(ph[\"TraitB.DGE\"], ph[\"TraitB.IGE\"])[0, 1]\n",
     "print(f\"cov(DGE, IGE)              = {cov_dge_ige:+.3f}   theoretical ~{(0.5*h2_B*B_vIGE)**0.5:+.3f}\")\n",
-    "print(f\"var(TraitB)                = {ph['TraitB'].var():.3f}   inflated by 2·cov(DGE, IGE) — see below\")"
+    "print(f\"var(TraitB)                = {ph['TraitB'].var():.3f}   inflated by 2*cov(DGE,IGE)\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5b5e5619",
+   "id": "5190ce98",
    "metadata": {},
    "source": [
-    "The total `var(TraitB)` is genuinely above 1 — that's the\n",
-    "biological DGE↔IGE confound at work. Without the T/NT split it would be\n",
-    "unrecoverable. With it, we can identify the indirect channel cleanly,\n",
-    "which is the next section."
+    "The total $\\mathrm{var}(\\text{TraitB})$ is genuinely above 1:\n",
+    "that's the biological DGE/IGE confound at work. Without the T/NT split\n",
+    "it would be unrecoverable. With it, we can identify the indirect channel\n",
+    "cleanly, which is the next section.\n",
+    "\n",
+    "The theoretical cov above comes from\n",
+    "$\\mathrm{cov}(\\text{DGE}, \\text{IGE}) = \\alpha_m \\mathrm{var}(T_{\\text{mat}}) + \\alpha_f \\mathrm{var}(T_{\\text{pat}}) = \\sqrt{0.5\\, h_B^2\\, B_{\\text{vIGE}}}$\n",
+    "under the orthogonality of $T_{\\text{mat}}, T_{\\text{pat}}, \\mathrm{NT}_m, \\mathrm{NT}_f$\n",
+    "at random mating."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "66333472",
+   "id": "522f307a",
    "metadata": {},
    "source": [
     "## 5. Estimating direct and indirect coefficients\n",
     "\n",
-    "Under the model in §4:\n",
+    "Under the model in $\\S 4$, child phenotype decomposes (up to a centering\n",
+    "constant) as\n",
     "\n",
-    "```\n",
-    "child_TraitB = (T_mat + T_pat)\n",
-    "             + α_m · (T_mat + NT_m)           # IGE_src_m ≈ (T_mat + NT_m) up to scale\n",
-    "             + α_f · (T_pat + NT_f)\n",
-    "             + E\n",
-    "           = T_mat·(1+α_m) + T_pat·(1+α_f) + α_m·NT_m + α_f·NT_f + E\n",
-    "```\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "\\text{child TraitB}\n",
+    "&= (T_{\\text{mat}} + T_{\\text{pat}}) \\\\\n",
+    "&\\quad + \\alpha_m \\cdot (T_{\\text{mat}} + \\mathrm{NT}_m) + \\alpha_f \\cdot (T_{\\text{pat}} + \\mathrm{NT}_f) \\\\\n",
+    "&\\quad + E \\\\\n",
+    "&= T_{\\text{mat}} (1 + \\alpha_m) + T_{\\text{pat}} (1 + \\alpha_f)\n",
+    "+ \\alpha_m\\, \\mathrm{NT}_m + \\alpha_f\\, \\mathrm{NT}_f + E,\n",
+    "\\end{aligned}\n",
+    "$$\n",
     "\n",
-    "where `α_m ≈ sqrt(B_vIGE · p_mom / var(parental_DGE))` is the realized\n",
-    "coefficient on the parent's *raw* DGE in the IGE channel after the\n",
-    "internal normalize-by-SD step. So an OLS regression of child phenotype\n",
-    "on the four columns recovers:\n",
+    "where\n",
+    "$\\alpha_m = \\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{mom}} / \\mathrm{var}(\\text{parental DGE})}$\n",
+    "is the realized coefficient on the parent's *raw* DGE in the IGE\n",
+    "channel after the internal `normalize=True` step. So an OLS regression\n",
+    "of child phenotype on the four columns recovers:\n",
     "\n",
-    "* `β(T_mat) = 1 + α_m`,  `β(T_pat) = 1 + α_f`\n",
-    "* `β(NT_m) = α_m`,        `β(NT_f) = α_f`\n",
+    "$$\n",
+    "\\hat\\beta(T_{\\text{mat}}) = 1 + \\alpha_m, \\qquad\n",
+    "\\hat\\beta(T_{\\text{pat}}) = 1 + \\alpha_f, \\qquad\n",
+    "\\hat\\beta(\\mathrm{NT}_m) = \\alpha_m, \\qquad\n",
+    "\\hat\\beta(\\mathrm{NT}_f) = \\alpha_f.\n",
+    "$$\n",
     "\n",
     "Subtracting the NT coefficient from the matching T coefficient yields\n",
     "the **direct effect of one allele's worth of polygenic score on the\n",
-    "child's phenotype** (~1 by construction — we built the model so that a\n",
-    "unit of parental DGE adds a unit to child DGE, plus its IGE pathway).\n",
+    "child's phenotype**, which is $1$ by construction (we built the model\n",
+    "so that a unit of parental DGE adds a unit to child DGE, plus its IGE\n",
+    "pathway).\n",
     "\n",
-    "We re-run the §4 model at a larger sample size for tight estimates, then\n",
-    "fit the regression."
+    "We re-run the $\\S 4$ model at a larger sample size for tight estimates,\n",
+    "then fit the regression."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "de17965c",
+   "id": "263b1ba6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:52.582416Z",
-     "iopub.status.busy": "2026-04-25T01:40:52.582318Z",
-     "iopub.status.idle": "2026-04-25T01:40:53.443060Z",
-     "shell.execute_reply": "2026-04-25T01:40:53.442679Z"
+     "iopub.execute_input": "2026-04-25T01:51:52.926244Z",
+     "iopub.status.busy": "2026-04-25T01:51:52.926098Z",
+     "iopub.status.idle": "2026-04-25T01:51:53.773873Z",
+     "shell.execute_reply": "2026-04-25T01:51:53.773224Z"
     }
    },
    "outputs": [
@@ -577,37 +606,37 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>intercept</th>\n",
-       "      <td>1.278768</td>\n",
+       "      <td>1.278792</td>\n",
        "      <td>0.005012</td>\n",
-       "      <td>255.161833</td>\n",
+       "      <td>255.141930</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_mat</th>\n",
-       "      <td>1.631614</td>\n",
-       "      <td>0.004459</td>\n",
-       "      <td>365.940428</td>\n",
+       "      <td>1.631543</td>\n",
+       "      <td>0.004469</td>\n",
+       "      <td>365.043088</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_pat</th>\n",
-       "      <td>1.637219</td>\n",
-       "      <td>0.004441</td>\n",
-       "      <td>368.636537</td>\n",
+       "      <td>1.625945</td>\n",
+       "      <td>0.004432</td>\n",
+       "      <td>366.843860</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_m</th>\n",
-       "      <td>0.634530</td>\n",
-       "      <td>0.004511</td>\n",
-       "      <td>140.652121</td>\n",
+       "      <td>0.634427</td>\n",
+       "      <td>0.004509</td>\n",
+       "      <td>140.701101</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_f</th>\n",
-       "      <td>0.620610</td>\n",
-       "      <td>0.004475</td>\n",
-       "      <td>138.679488</td>\n",
+       "      <td>0.632041</td>\n",
+       "      <td>0.004453</td>\n",
+       "      <td>141.934510</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -616,11 +645,11 @@
       ],
       "text/plain": [
        "           estimate  std_error     t_value  p_value\n",
-       "intercept  1.278768   0.005012  255.161833      0.0\n",
-       "T_mat      1.631614   0.004459  365.940428      0.0\n",
-       "T_pat      1.637219   0.004441  368.636537      0.0\n",
-       "NT_m       0.634530   0.004511  140.652121      0.0\n",
-       "NT_f       0.620610   0.004475  138.679488      0.0"
+       "intercept  1.278792   0.005012  255.141930      0.0\n",
+       "T_mat      1.631543   0.004469  365.043088      0.0\n",
+       "T_pat      1.625945   0.004432  366.843860      0.0\n",
+       "NT_m       0.634427   0.004509  140.701101      0.0\n",
+       "NT_f       0.632041   0.004453  141.934510      0.0"
       ]
      },
      "execution_count": 6,
@@ -672,25 +701,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64b2042a",
+   "id": "9569e75c",
    "metadata": {},
    "source": [
     "Compare against the theoretical targets. We seeded the IGE\n",
-    "channel with coefficient `sqrt(B_vIGE · p_parent)` on a *standardized*\n",
-    "parental DGE, so the realized coefficient on the raw parental DGE is\n",
-    "`α = sqrt(B_vIGE · p_parent / var(parental_DGE))`."
+    "channel with coefficient $\\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{parent}}}$\n",
+    "on a *standardized* parental DGE, so the realized coefficient on the\n",
+    "raw parental DGE is\n",
+    "\n",
+    "$$\n",
+    "\\alpha = \\sqrt{B_{\\text{vIGE}} \\cdot p_{\\text{parent}} / \\mathrm{var}(\\text{parental DGE})}.\n",
+    "$$"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "dc9d1f56",
+   "id": "aac7b848",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:53.444045Z",
-     "iopub.status.busy": "2026-04-25T01:40:53.443944Z",
-     "iopub.status.idle": "2026-04-25T01:40:53.449120Z",
-     "shell.execute_reply": "2026-04-25T01:40:53.448860Z"
+     "iopub.execute_input": "2026-04-25T01:51:53.775149Z",
+     "iopub.status.busy": "2026-04-25T01:51:53.775056Z",
+     "iopub.status.idle": "2026-04-25T01:51:53.780899Z",
+     "shell.execute_reply": "2026-04-25T01:51:53.780348Z"
     }
    },
    "outputs": [
@@ -724,32 +757,32 @@
        "    <tr>\n",
        "      <th>intercept</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>1.278768</td>\n",
+       "      <td>1.278792</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_mat</th>\n",
        "      <td>1.630436</td>\n",
-       "      <td>1.631614</td>\n",
-       "      <td>0.001178</td>\n",
+       "      <td>1.631543</td>\n",
+       "      <td>0.001107</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>T_pat</th>\n",
        "      <td>1.630436</td>\n",
-       "      <td>1.637219</td>\n",
-       "      <td>0.006783</td>\n",
+       "      <td>1.625945</td>\n",
+       "      <td>-0.004492</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_m</th>\n",
        "      <td>0.630436</td>\n",
-       "      <td>0.634530</td>\n",
-       "      <td>0.004094</td>\n",
+       "      <td>0.634427</td>\n",
+       "      <td>0.003990</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>NT_f</th>\n",
        "      <td>0.630436</td>\n",
-       "      <td>0.620610</td>\n",
-       "      <td>-0.009827</td>\n",
+       "      <td>0.632041</td>\n",
+       "      <td>0.001605</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -757,11 +790,11 @@
       ],
       "text/plain": [
        "           theoretical  estimate     error\n",
-       "intercept          NaN  1.278768       NaN\n",
-       "T_mat         1.630436  1.631614  0.001178\n",
-       "T_pat         1.630436  1.637219  0.006783\n",
-       "NT_m          0.630436  0.634530  0.004094\n",
-       "NT_f          0.630436  0.620610 -0.009827"
+       "intercept          NaN  1.278792       NaN\n",
+       "T_mat         1.630436  1.631543  0.001107\n",
+       "T_pat         1.630436  1.625945 -0.004492\n",
+       "NT_m          0.630436  0.634427  0.003990\n",
+       "NT_f          0.630436  0.632041  0.001605"
       ]
      },
      "execution_count": 7,
@@ -784,30 +817,32 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9669c711",
+   "id": "4d74af23",
    "metadata": {},
    "source": [
-    "**Direct effect** (per allele unit of polygenic score) is recovered as\n",
-    "`β(T_mat) − β(NT_m)` and `β(T_pat) − β(NT_f)`, both of which should sit\n",
-    "at `1.0`. **Indirect effect** is `β(NT_m)` and `β(NT_f)`, which match\n",
-    "`α_m` and `α_f` directly.\n",
+    "**Direct effect** (per allele unit of polygenic score) is recovered\n",
+    "as $\\hat\\beta(T_{\\text{mat}}) - \\hat\\beta(\\mathrm{NT}_m)$ and\n",
+    "$\\hat\\beta(T_{\\text{pat}}) - \\hat\\beta(\\mathrm{NT}_f)$, both of which\n",
+    "should sit at $1.0$. **Indirect effect** is $\\hat\\beta(\\mathrm{NT}_m)$\n",
+    "and $\\hat\\beta(\\mathrm{NT}_f)$, which match $\\alpha_m$ and $\\alpha_f$\n",
+    "directly.\n",
     "\n",
-    "Notice that the simple regression of child phenotype on its own DGE\n",
-    "*without* NT controls would over-attribute the indirect channel to the\n",
-    "direct channel — the classical \"dynastic confound.\" Throw it in for\n",
+    "The simple regression of child phenotype on its own DGE *without* NT\n",
+    "controls would over-attribute the indirect channel to the direct\n",
+    "channel -- the classical \"dynastic confound.\" Throw it in for\n",
     "contrast:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4ada6f84",
+   "id": "895b9912",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:53.449874Z",
-     "iopub.status.busy": "2026-04-25T01:40:53.449783Z",
-     "iopub.status.idle": "2026-04-25T01:40:53.466782Z",
-     "shell.execute_reply": "2026-04-25T01:40:53.466508Z"
+     "iopub.execute_input": "2026-04-25T01:51:53.781969Z",
+     "iopub.status.busy": "2026-04-25T01:51:53.781882Z",
+     "iopub.status.idle": "2026-04-25T01:51:53.799039Z",
+     "shell.execute_reply": "2026-04-25T01:51:53.798733Z"
     }
    },
    "outputs": [
@@ -815,7 +850,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "naive direct estimate = 1.641  (should be ~1.630, conflating direct + indirect)\n"
+      "naive direct estimate = 1.635  (should be ~1.630, conflating direct + indirect)\n"
      ]
     }
    ],
@@ -827,7 +862,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d39ea597",
+   "id": "00e2c2d3",
    "metadata": {},
    "source": [
     "## 6. Layering on assortative mating\n",
@@ -835,30 +870,30 @@
     "`xftsim.nmate.LinearAssortativeMating` rank-pairs each sex on a\n",
     "phenotypic composite (sum of standardized components from\n",
     "`component_names`). The `r` argument is the **target per-cell exchangeable\n",
-    "cross-mate correlation** under K traits.\n",
+    "cross-mate correlation** under $K$ traits.\n",
     "\n",
-    "* **K = 1**: the spousal correlation on that single trait is `≈ r`.\n",
-    "* **K > 1**: every (parent1_t_i, parent2_t_j) cell — both diagonal\n",
-    "  (per-trait) and off-diagonal (cross-trait) — is targeted at `r`.\n",
-    "  Feasibility bound is `|r| ≤ 1/K`. Beyond that the latent score\n",
-    "  correlation `R = K·r` saturates and you get less assortment than you\n",
-    "  asked for.\n",
+    "* **$K = 1$**: the spousal correlation on that single trait is $\\approx r$.\n",
+    "* **$K > 1$**: every $(\\text{parent}_1\\, t_i, \\text{parent}_2\\, t_j)$\n",
+    "  cell -- both diagonal (per-trait) and off-diagonal (cross-trait) --\n",
+    "  is targeted at $r$. Feasibility bound is $|r| \\le 1/K$. Beyond that\n",
+    "  the latent score correlation $R = K \\cdot r$ saturates and you get\n",
+    "  less assortment than you asked for.\n",
     "\n",
-    "The current implementation **warns** at construction when `|r| > 1/K`,\n",
-    "and again at runtime when the realized `R` exceeds 1. Below: each of the\n",
-    "three regimes, side by side."
+    "The current implementation **warns** at construction when $|r| > 1/K$,\n",
+    "and again at runtime when the realized $R$ exceeds 1. Below: each of\n",
+    "the three regimes, side by side."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "eb9b7faf",
+   "id": "1dcb44ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T01:40:53.467626Z",
-     "iopub.status.busy": "2026-04-25T01:40:53.467455Z",
-     "iopub.status.idle": "2026-04-25T01:40:56.157476Z",
-     "shell.execute_reply": "2026-04-25T01:40:56.156992Z"
+     "iopub.execute_input": "2026-04-25T01:51:53.800679Z",
+     "iopub.status.busy": "2026-04-25T01:51:53.800269Z",
+     "iopub.status.idle": "2026-04-25T01:51:56.452195Z",
+     "shell.execute_reply": "2026-04-25T01:51:56.451694Z"
     }
    },
    "outputs": [
@@ -888,8 +923,8 @@
      "output_type": "stream",
      "text": [
       "cross-trait r=0.75 (K=2, INFEASIBLE) cor(A,A)=+0.504  cor(B,B)=+0.504  cor(A,B)=+0.515  cor(B,A)=+0.500\n",
-      "  warn: LinearAssortativeMating: |r|=0.75 exceeds 1/K=0.5 for K=2 traits. Under uncorrelated within-person traits this target is…\n",
-      "  warn: LinearAssortativeMating: realized latent score correlation R=1.48 exceeds 1 for r=0.75, K=2. Clamping to 0.999 (assortme…\n"
+      "  warn: LinearAssortativeMating: |r|=0.75 exceeds 1/K=0.5 for K=2 traits. Under uncorrelated within-person traits this target is...\n",
+      "  warn: LinearAssortativeMating: realized latent score correlation R=1.48 exceeds 1 for r=0.75, K=2. Clamping to 0.999 (assortme...\n"
      ]
     }
    ],
@@ -929,7 +964,7 @@
     "    print(f\"{label:35s} cor(A,A)={rAA:+.3f}  cor(B,B)={rBB:+.3f}  \"\n",
     "          f\"cor(A,B)={rAB:+.3f}  cor(B,A)={rBA:+.3f}\")\n",
     "\n",
-    "# 1) random mating — baseline\n",
+    "# 1) random mating -- baseline\n",
     "run_am(RandomMating(offspring_per_pair=2),\n",
     "       \"random\")\n",
     "\n",
@@ -938,12 +973,12 @@
     "                                offspring_per_pair=2),\n",
     "       \"single-trait r=0.3 on TraitA\")\n",
     "\n",
-    "# 3) cross-trait AM — feasible (|r| <= 1/K = 0.5)\n",
+    "# 3) cross-trait AM -- feasible (|r| <= 1/K = 0.5)\n",
     "run_am(LinearAssortativeMating(component_names=[\"TraitA\", \"TraitB\"], r=0.3,\n",
     "                                offspring_per_pair=2),\n",
     "       \"cross-trait r=0.3 (K=2, feasible)\")\n",
     "\n",
-    "# 4) cross-trait AM — infeasible: should warn at construction AND at runtime\n",
+    "# 4) cross-trait AM -- infeasible: should warn at construction AND at runtime\n",
     "with warnings.catch_warnings(record=True) as caught:\n",
     "    warnings.simplefilter(\"always\")\n",
     "    run_am(LinearAssortativeMating(component_names=[\"TraitA\", \"TraitB\"], r=0.75,\n",
@@ -951,24 +986,26 @@
     "           \"cross-trait r=0.75 (K=2, INFEASIBLE)\")\n",
     "    for w in caught:\n",
     "        if \"LinearAssortativeMating\" in str(w.message):\n",
-    "            print(f\"  warn: {str(w.message)[:120]}…\")"
+    "            print(f\"  warn: {str(w.message)[:120]}...\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "27dfab0c",
+   "id": "a6661949",
    "metadata": {},
    "source": [
     "**Reading the matrix:** under exchangeable cross-trait AM with\n",
-    "`r = 0.3` you'd want all four (A,A), (B,B), (A,B), (B,A) parental\n",
-    "correlations close to 0.3. With `r = 0.75` they all top out around 0.5\n",
-    "because the latent score correlation got clamped at saturation.\n",
+    "$r = 0.3$ all four parental correlations -- $(A,A)$, $(B,B)$, $(A,B)$,\n",
+    "$(B,A)$ -- should sit close to $0.3$. With $r = 0.75$ they all top out\n",
+    "around $0.5$ because the latent score correlation got clamped at\n",
+    "saturation.\n",
     "\n",
     "**Putting it all together:** to reproduce a study of indirect genetic\n",
-    "effects under assortment, swap §6's mating regime into §4's architecture\n",
-    "and re-run §5's NTC regression. Under AM, `var(parent_DGE)` inflates each\n",
-    "generation, so `α_m`, `α_f` will drift from their gen-0 values — but\n",
-    "they remain identifiable from the OLS fit, generation by generation."
+    "effects under assortment, swap $\\S 6$'s mating regime into $\\S 4$'s\n",
+    "architecture and re-run $\\S 5$'s NTC regression. Under AM,\n",
+    "$\\mathrm{var}(\\text{parent DGE})$ inflates each generation, so\n",
+    "$\\alpha_m, \\alpha_f$ will drift from their gen-0 values, but they remain\n",
+    "identifiable from the OLS fit, generation by generation."
    ]
   }
  ],

--- a/scripts/run_xftsim_AM.py
+++ b/scripts/run_xftsim_AM.py
@@ -1,0 +1,449 @@
+"""Family simulation with clean DGE / IGE / E partition.
+
+Re-implementation of an older xftsim family simulation against the new
+numpy-backed API on the `ajay`/`ap_indirect` branch. The architecture is
+deliberately structured so that direct genetic, indirect genetic, and
+non-genetic components are separable in the output, and so that the
+transmitted vs non-transmitted parental allele effects can be recovered
+exactly via subtraction of genetic values.
+
+Per-trait components written to `phenotype_history[g]`:
+
+    <T>.T_mat, <T>.T_pat   transmitted DGE, by parent of origin
+    <T>.DGE                child's own direct genetic score (= T_mat + T_pat)
+    <T>.PDGE_m, <T>.PDGE_f full parental DGE (lookup; normalize=False)
+    <T>.NT_m, <T>.NT_f     non-transmitted parental DGE (= PDGE - T)
+    <T>.E                  environmental / non-genetic
+    <T>.IGE                indirect genetic effect (TraitB only under the
+                           collaborator's model). Sourced from FULL parental
+                           DGE (= T + NT), reflecting the biological
+                           pathway parent_genome → parent_phenotype →
+                           child_environment → child_phenotype. Variance
+                           pinned to B_vIGE every generation via a
+                           normalize=True parental lookup.
+    <T>                    total phenotype (sum of DGE + E [+ IGE])
+
+Note on total phenotype variance under IGE: because IGE sources from
+parent's full DGE, transmitted alleles influence the child *both*
+directly (via child's own DGE) and indirectly (via parental phenotype).
+This induces a positive cov(child DGE, child IGE) of order
+sqrt(0.5·B_DGE·B_vIGE), inflating var(<T>) above the marginal-component
+sum. That confound is a real biological feature; the T_mat / T_pat /
+NT_m / NT_f outputs are emitted precisely so downstream analyses (e.g.
+Kong-style non-transmitted-coefficient estimators) can identify the
+pure indirect effect.
+
+First-cut scope: uniform-AF founders, uniform recombination, random /
+single-trait AM / cross-trait AM, TraitB-only IGE. Empirical genomes,
+pyrho recombination maps, VCF output, and popstrat are deferred.
+
+The phenotype_component_covariances file is emitted as a DataFrame via
+pandas.to_pickle matching the original collaborator-side spec; the file
+is a simulation artifact consumed only by the same analysis pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import traceback
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from xftsim.founders import founder_haplotypes_uniform_AFs
+from xftsim.narch import Architecture
+from xftsim.neffect import AdditiveEffects
+from xftsim.nmate import LinearAssortativeMating, RandomMating
+from xftsim.nsim import NSimulation
+from xftsim.reproduce import RecombinationMap
+
+
+# ---------------------------------------------------------------------------
+# Architecture
+# ---------------------------------------------------------------------------
+
+def draw_bivariate_dge_betas(A_DGE, B_DGE, DGE_ABcov, afs, rng):
+    """Draw an (m, 2) bivariate-normal per-allele beta matrix.
+
+    DGE_ABcov is a correlation in [-1, 1]. Betas are drawn in standardized-
+    genotype convention and then rescaled by 1/sqrt(2·p·(1-p)) per SNP.
+
+    Why: HaplotypeGeneticComponent uses raw 0/1 haplotype dosages (it does
+    not call standardized_matvec), so for E[var(DGE)] ≈ h² the per-allele
+    effect β on raw dosages must satisfy Σ 2p(1-p)·β² = h². Drawing
+    β_std ~ N(0, h²/m) and setting β = β_std / sqrt(2p(1-p)) achieves this.
+    """
+    m = len(afs)
+    cov_snp = np.array([
+        [A_DGE / m,                                   DGE_ABcov * np.sqrt(A_DGE * B_DGE) / m],
+        [DGE_ABcov * np.sqrt(A_DGE * B_DGE) / m,      B_DGE / m],
+    ])
+    betas_std = rng.multivariate_normal(mean=[0.0, 0.0], cov=cov_snp, size=m)
+    scale = 1.0 / np.sqrt(2.0 * afs * (1.0 - afs))
+    return betas_std * scale[:, None]
+
+
+def build_architecture(trait_names, trait_variances, ige_config, betas, *,
+                        founder_dge_var):
+    """Build the formula DSL string and effects dict.
+
+    Parameters
+    ----------
+    trait_names : list[str]
+        e.g. ['TraitA', 'TraitB']. Length 1 or 2.
+    trait_variances : dict[str, dict]
+        Per trait: {'DGE': float, 'E': float, 'IGE': float}. 'IGE' is
+        total IGE variance on the trait (0 for traits without IGE).
+    ige_config : dict or None
+        {'trait': 'TraitB', 'p_mom': 0.5, 'p_dad': 0.5} or None.
+    betas : dict[str, np.ndarray]
+        Per trait: 1-D effect array of length m.
+    founder_dge_var : dict[str, float]
+        Stand-in var for PDGE lookup at gen 0 (≈ DGE variance per trait).
+
+    Returns
+    -------
+    (formula_str, effects_dict)
+    """
+    effects = {}
+    lines = []
+
+    for T in trait_names:
+        eff_name = f"{T}_eff"
+        # standardized=False: betas are already on the raw-dosage scale
+        # (rescaled by 1/sqrt(2p(1-p)) in draw_bivariate_dge_betas).
+        effects[eff_name] = AdditiveEffects.from_array(betas[T], standardized=False)
+        # Per-haplotype DGE (transmitted allele scores, by parent of origin)
+        lines.append(f"{T}.T_mat ~ haplotypeGenetic({eff_name}, haplotype='maternal')")
+        lines.append(f"{T}.T_pat ~ haplotypeGenetic({eff_name}, haplotype='paternal')")
+        lines.append(f"{T}.DGE ~ {T}.T_mat + {T}.T_pat")
+        # Environment
+        lines.append(f"{T}.E ~ noise({trait_variances[T]['E']})")
+
+    if ige_config is not None:
+        T = ige_config['trait']
+        v = trait_variances[T]['IGE']
+        p_mom = ige_config['p_mom']
+        p_dad = ige_config['p_dad']
+
+        # Raw parental full DGE — used for T/NT subtraction in genetic-score
+        # units. normalize=False keeps the PDGE value on the same scale as
+        # the child's haplotypeGenetic outputs, so subtraction yields the
+        # *actual* effect of the non-transmitted parental haplotype.
+        lines.append(
+            f"{T}.PDGE_m ~ mother({T}.DGE, normalize=False, "
+            f"founder=noise({founder_dge_var[T]}))"
+        )
+        lines.append(
+            f"{T}.PDGE_f ~ father({T}.DGE, normalize=False, "
+            f"founder=noise({founder_dge_var[T]}))"
+        )
+        lines.append(f"{T}.NT_m ~ {T}.PDGE_m - {T}.T_mat")
+        lines.append(f"{T}.NT_f ~ {T}.PDGE_f - {T}.T_pat")
+
+        # Separate normalize=True lookup feeds the IGE channel. Standardizing
+        # each generation pins var(IGE) to v (= B_vIGE) regardless of drift
+        # or AM-induced variance inflation in parental DGE.
+        lines.append(
+            f"{T}.IGE_src_m ~ mother({T}.DGE, normalize=True, founder=noise(1.0))"
+        )
+        lines.append(
+            f"{T}.IGE_src_f ~ father({T}.DGE, normalize=True, founder=noise(1.0))"
+        )
+        c_m = np.sqrt(v * p_mom)
+        c_d = np.sqrt(v * p_dad)
+        lines.append(f"{T}.IGE ~ {c_m} * {T}.IGE_src_m + {c_d} * {T}.IGE_src_f")
+
+    # Totals
+    for T in trait_names:
+        parts = [f"{T}.DGE", f"{T}.E"]
+        if ige_config is not None and ige_config['trait'] == T:
+            parts.append(f"{T}.IGE")
+        lines.append(f"{T} ~ " + " + ".join(parts))
+
+    formula = "\n".join(lines)
+    return formula, effects
+
+
+# ---------------------------------------------------------------------------
+# Mating regime
+# ---------------------------------------------------------------------------
+
+def build_mating_regime(AMmode, AMtrait, AMcorr, trait_names):
+    """Construct the mating regime per spec.
+
+    Note: the original collaborator's script multiplied AMcorr by 3 in
+    `cross` mode. That factor was specific to the *old* API's internal
+    `r` parameterization. In the new API, `r` is documented as the
+    target per-trait spousal correlation, so AMcorr is passed through
+    unchanged for both single- and cross-trait AM here.
+    """
+    if AMmode == "random" or AMcorr == 0.0:
+        return RandomMating(offspring_per_pair=2)
+    if AMmode == "single":
+        if AMtrait not in trait_names:
+            raise ValueError(
+                f"--AMtrait {AMtrait} not in trait list {trait_names}"
+            )
+        return LinearAssortativeMating(
+            component_names=[AMtrait], r=AMcorr, offspring_per_pair=2,
+        )
+    if AMmode == "cross":
+        return LinearAssortativeMating(
+            component_names=list(trait_names), r=AMcorr, offspring_per_pair=2,
+        )
+    raise ValueError(f"unknown AMmode={AMmode}")
+
+
+# ---------------------------------------------------------------------------
+# Output writers
+# ---------------------------------------------------------------------------
+
+def write_trios(sim, child_gen, out_dir):
+    """Write a (child_iid, parent1_iid, parent2_iid) table keyed by family.
+
+    Under `offspring_per_pair=2`, each family has two siblings in the
+    child generation; we keep the first-seen sibling per FID.
+    """
+    child = sim.phenotype_history[child_gen].samples
+    parent = sim.phenotype_history[child_gen - 1].samples
+    ped = sim.pedigree_history[child_gen]
+
+    # First offspring per family
+    _, first_idx = np.unique(child.fid, return_index=True)
+    first_idx = np.sort(first_idx)
+
+    mom_iid = parent.iid[ped.maternal_idx[first_idx]]
+    dad_iid = parent.iid[ped.paternal_idx[first_idx]]
+    kid_iid = child.iid[first_idx]
+
+    df = pd.DataFrame({
+        'child':   _as_str(kid_iid),
+        'parent1': _as_str(mom_iid),
+        'parent2': _as_str(dad_iid),
+    })
+    df.to_csv(out_dir / "trios.tab", sep="\t", header=False, index=False)
+    return df, first_idx
+
+
+def write_child_phenotypes(sim, child_gen, first_idx, trait_names, out_dir):
+    """Per-trait TSVs: one row per trio-child, columns [ID, VAL]."""
+    ph = sim.phenotype_history[child_gen]
+    iid = _as_str(ph.samples.iid[first_idx])
+    for T in trait_names:
+        vals = ph[T][first_idx]
+        pd.DataFrame({'ID': iid, 'VAL': vals}).to_csv(
+            out_dir / f"children{T}.tab", sep="\t", header=False, index=False,
+        )
+
+
+def write_dge_betas(betas, trait_names, m, out_dir):
+    """Write per-variant DGE betas in a single CSV indexed by vid."""
+    vid = np.arange(m, dtype=int)
+    df = pd.DataFrame({T: betas[T] for T in trait_names}, index=vid)
+    df.index.name = 'vid'
+    df.to_csv(out_dir / "xftsim_DGE_betas.csv")
+
+
+def write_parent_child_phenotypes(sim, child_gen, trios_df, trait_names,
+                                   has_ige, ige_trait, out_dir):
+    """Wide parent-child table with phenotype and every component column.
+
+    Keeps the DGE / IGE / E partition (and T/NT for the IGE trait) visible
+    in the output so downstream analyses can compare transmitted vs
+    non-transmitted allele effects directly.
+    """
+    child = sim.phenotype_history[child_gen]
+    parent = sim.phenotype_history[child_gen - 1]
+    child_iid = _as_str(child.samples.iid)
+    parent_iid = _as_str(parent.samples.iid)
+
+    child_df = pd.DataFrame({k: child[k] for k in child.keys}, index=child_iid)
+    parent_df = pd.DataFrame({k: parent[k] for k in parent.keys}, index=parent_iid)
+
+    per_trait_cols = []
+    for T in trait_names:
+        per_trait_cols.extend([T, f"{T}.DGE", f"{T}.E"])
+    if has_ige:
+        T = ige_trait
+        per_trait_cols.extend([
+            f"{T}.IGE",
+            f"{T}.T_mat", f"{T}.T_pat",
+            f"{T}.NT_m",  f"{T}.NT_f",
+            f"{T}.PDGE_m", f"{T}.PDGE_f",
+        ])
+
+    out = trios_df.copy()
+    for col in per_trait_cols:
+        out[f"child_{col}"]   = out.child.map(child_df[col])
+        out[f"parent1_{col}"] = out.parent1.map(parent_df[col])
+        out[f"parent2_{col}"] = out.parent2.map(parent_df[col])
+
+    out = out.dropna()
+    out.to_csv(
+        out_dir / "parent_child_phenotypes.txt",
+        sep=" ", header=True, index=False,
+    )
+    return out
+
+
+def write_component_covariance(sim, child_gen, first_idx, out_dir):
+    """Pickle the covariance of trio-child phenotype components."""
+    ph = sim.phenotype_history[child_gen]
+    df = pd.DataFrame({k: ph[k][first_idx] for k in ph.keys})
+    df.cov().to_pickle(out_dir / "phenotype_component_covariances.pkl")
+
+
+def _as_str(arr):
+    return np.asarray(arr).astype(str)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--founder_zarr', default=None)
+    p.add_argument('--chr_count', type=int, default=1)
+    p.add_argument('--nfam', type=int, required=True)
+    p.add_argument('--empirical_genomes', choices=["True", "False"], default="False")
+    p.add_argument('--empirical_recombination', choices=["True", "False"], default="False")
+    p.add_argument('--recombination_path_template', default=None)
+    p.add_argument('--p_IGEmom', type=float, default=0.5)
+    p.add_argument('--p_IGEdad', type=float, default=0.5)
+    p.add_argument('--A_DGE', type=float, required=True)
+    p.add_argument('--B_DGE', type=float, required=True)
+    p.add_argument('--DGE_ABcov', type=float, required=True,
+                   help="Correlation (not covariance) between TraitA and TraitB DGE effects, in [-1, 1].")
+    p.add_argument('--B_vIGE', type=float, required=True)
+    p.add_argument('--generations', type=int, required=True)
+    p.add_argument('--out_directory', required=True)
+    p.add_argument('--replicate', required=True)
+    p.add_argument('--output_format', choices=["vcf", "plink"], default="vcf")
+    p.add_argument('--AMmode', choices=["random", "single", "cross"], required=True)
+    p.add_argument('--AMtrait', choices=["TraitA", "TraitB"], default="TraitB")
+    p.add_argument('--AMcorr', type=float, required=True)
+    p.add_argument('--selected_chrs', type=int, nargs='+', default=None)
+    p.add_argument('--trait_count', type=int, choices=[1, 2], default=2)
+    p.add_argument('--popstrat', type=int, choices=[0, 1], default=0)
+    p.add_argument('--snps_per_chr', type=int, default=10_000,
+                   help="Synthetic-founders only: SNPs per chromosome when --empirical_genomes=False.")
+    p.add_argument('--seed', type=int, default=None)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.generations < 2:
+        raise ValueError("--generations must be >= 2")
+    if args.empirical_genomes == "True":
+        raise NotImplementedError(
+            "empirical_genomes=True (sgkit/zarr loader) is deferred; "
+            "run with --empirical_genomes False for now."
+        )
+    if args.empirical_recombination == "True":
+        raise NotImplementedError(
+            "empirical_recombination=True (pyrho map) is deferred."
+        )
+    if args.output_format == "vcf":
+        print("[warn] VCF output deferred; skipping chr*.vcf.gz generation.",
+              file=sys.stderr)
+    if args.popstrat == 1:
+        raise NotImplementedError("--popstrat 1 (two-cohort drift) deferred.")
+
+    rng = np.random.default_rng(args.seed)
+
+    out_dir = Path(args.out_directory) / f"replicate_{args.replicate}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Founders ----------------------------------------------------------
+    m = args.snps_per_chr * args.chr_count
+    n_samples = 2 * args.nfam
+    founder_hap = founder_haplotypes_uniform_AFs(n=n_samples, m=m)
+
+    # --- Effect sizes ------------------------------------------------------
+    all_trait_names = ["TraitA", "TraitB"]
+    trait_names = all_trait_names[: args.trait_count]
+
+    afs = np.asarray(founder_hap.variants.af, dtype=np.float64)
+    beta_mat = draw_bivariate_dge_betas(
+        args.A_DGE, args.B_DGE, args.DGE_ABcov, afs, rng,
+    )
+    betas = {T: beta_mat[:, i] for i, T in enumerate(all_trait_names)}
+
+    # --- Variances & IGE config -------------------------------------------
+    A_E = 1.0 - args.A_DGE
+    B_E = 1.0 - (args.B_DGE + args.B_vIGE)
+    if A_E < 0 or B_E < 0:
+        raise ValueError(
+            f"Residual E variance negative: A_E={A_E}, B_E={B_E}. "
+            "Check A_DGE, B_DGE, B_vIGE."
+        )
+
+    trait_variances = {
+        "TraitA": {"DGE": args.A_DGE, "E": A_E, "IGE": 0.0},
+        "TraitB": {"DGE": args.B_DGE, "E": B_E, "IGE": args.B_vIGE},
+    }
+    founder_dge_var = {"TraitA": args.A_DGE, "TraitB": args.B_DGE}
+
+    has_ige = args.B_vIGE > 0 and "TraitB" in trait_names
+    ige_config = None
+    if has_ige:
+        ige_config = {
+            "trait": "TraitB",
+            "p_mom": args.p_IGEmom,
+            "p_dad": args.p_IGEdad,
+        }
+
+    # --- Architecture ------------------------------------------------------
+    formula, effects = build_architecture(
+        trait_names, trait_variances, ige_config,
+        {T: betas[T] for T in trait_names},
+        founder_dge_var=founder_dge_var,
+    )
+    arch = Architecture(formula=formula, effects=effects)
+
+    # --- Recombination & mating -------------------------------------------
+    rmap = RecombinationMap.constant_map(m=m, p=0.5)
+    mating = build_mating_regime(
+        args.AMmode, args.AMtrait, args.AMcorr, trait_names,
+    )
+
+    # --- Run --------------------------------------------------------------
+    sim = NSimulation(
+        founder_haplotypes=founder_hap,
+        architecture=arch,
+        mating_regime=mating,
+        recombination_map=rmap,
+        seed=args.seed,
+    )
+    sim.run(args.generations)
+
+    # --- Outputs ----------------------------------------------------------
+    child_gen = args.generations - 1
+
+    trios_df, first_idx = write_trios(sim, child_gen, out_dir)
+    write_child_phenotypes(sim, child_gen, first_idx, trait_names, out_dir)
+    if args.A_DGE != 0 or args.B_DGE != 0:
+        write_dge_betas(betas, trait_names, m, out_dir)
+    write_parent_child_phenotypes(
+        sim, child_gen, trios_df, trait_names,
+        has_ige, "TraitB", out_dir,
+    )
+    write_component_covariance(sim, child_gen, first_idx, out_dir)
+
+    print(f"[ok] wrote replicate outputs to {out_dir}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()
+        os._exit(1)
+    os._exit(0)

--- a/xftsim/__init__.py
+++ b/xftsim/__init__.py
@@ -10,7 +10,7 @@ if sys.version_info < (3, 12):
         stacklevel=2,
     )
 
-__version__="0.3.0.dev109"
+__version__="0.3.0.dev110"
 
 
 class Config:

--- a/xftsim/__init__.py
+++ b/xftsim/__init__.py
@@ -10,7 +10,7 @@ if sys.version_info < (3, 12):
         stacklevel=2,
     )
 
-__version__="0.3.0.dev111"
+__version__="0.3.0.dev112"
 
 
 class Config:

--- a/xftsim/__init__.py
+++ b/xftsim/__init__.py
@@ -10,7 +10,7 @@ if sys.version_info < (3, 12):
         stacklevel=2,
     )
 
-__version__="0.3.0.dev112"
+__version__="0.3.0.dev113"
 
 
 class Config:

--- a/xftsim/__init__.py
+++ b/xftsim/__init__.py
@@ -10,7 +10,7 @@ if sys.version_info < (3, 12):
         stacklevel=2,
     )
 
-__version__="0.3.0.dev110"
+__version__="0.3.0.dev111"
 
 
 class Config:

--- a/xftsim/nmate.py
+++ b/xftsim/nmate.py
@@ -10,6 +10,7 @@ BatchedMating: wraps any mating regime, splitting individuals into batches.
 from __future__ import annotations
 
 import math
+import warnings
 
 import numpy as np
 from dataclasses import dataclass
@@ -196,6 +197,23 @@ class LinearAssortativeMating:
         self.r: float = float(r)
         self.offspring_per_pair: int = offspring_per_pair
 
+        # `r` is an exchangeable cross-mate cell-correlation target, so the
+        # feasibility bound is |r| <= 1/K under uncorrelated within-person
+        # traits. At runtime the bound shifts with within-person correlation,
+        # but a construction-time heads-up catches the common mistake of
+        # passing r > 1/K and getting saturated assortment.
+        K = len(self.component_names)
+        if K > 1 and abs(self.r) > 1.0 / K:
+            warnings.warn(
+                f"LinearAssortativeMating: |r|={abs(self.r):.3g} exceeds "
+                f"1/K={1.0/K:.3g} for K={K} traits. Under uncorrelated "
+                "within-person traits this target is infeasible; the "
+                "latent score correlation will saturate at ~1 and the "
+                "realized per-cell cross-mate correlation will fall short "
+                "of r.",
+                stacklevel=2,
+            )
+
     def mate(self, samples: SampleMeta,
              rng: np.random.RandomState | None = None,
              phenotypes: NPhenotypeArray | None = None) -> NMateAssignment:
@@ -272,7 +290,20 @@ class LinearAssortativeMating:
         else:
             R = abs(self.r)
 
-        R = min(R, 0.999)  # clamp to valid range
+        # Silently clamping here hides infeasibility (the old legacy regime
+        # just let sqrt(|1-R|) carry an inverted noise term, which masked
+        # the same problem in a different way). Warn loudly — the realized
+        # per-cell cross-mate correlation will fall short of r — then clamp
+        # so the rank-pairing still runs.
+        if R > 1.0:
+            warnings.warn(
+                f"LinearAssortativeMating: realized latent score correlation "
+                f"R={R:.3g} exceeds 1 for r={self.r:.3g}, K={K}. Clamping to "
+                "0.999 (assortment will saturate). Reduce |r| to <= 1/K or "
+                "fewer traits to reach the requested per-cell correlation.",
+                stacklevel=2,
+            )
+            R = 0.999
 
         # Mating score: sqrt(R) * sum + sqrt(1-R) * noise
         # Noise scaled to std of trait sum (matching legacy)


### PR DESCRIPTION
## Summary

- **`scripts/run_xftsim_AM.py`** — family simulation that re-implements an older collaborator's two-trait IGE setup against the new numpy-backed API. Architecture splits transmitted (`T_mat`, `T_pat`), non-transmitted (`NT_m`, `NT_f` via subtraction), direct (`DGE`), indirect (`IGE`, TraitB only, variance-pinned via a separate `normalize=True` parental lookup), and environmental components, so downstream NTC-style analyses can deconfound the genuine cov(child DGE, child IGE) baked into the biological model.
- **`xftsim/nmate.py`** — `LinearAssortativeMating` now warns at construction when `|r| > 1/K` (infeasible exchangeable target) and at mate-time when the realized latent score correlation exceeds 1, instead of silently clamping at 0.999.
- **`docs/examples/08_direct_indirect_effects.ipynb`** — tutorial that builds the architecture up in six stages (install → minimal sim → two correlated traits → per-haplotype split → IGE+T/NT → NTC estimation → AM with feasibility checks). NTC regression recovers the indirect coefficient within ~1% on a 10k-family run.

## Background

Spec was for a stand-alone simulation matching an older xftsim version's semantics; we kept only the architecture/AM parts and dropped the empirical-genome / pyrho / VCF / popstrat pipeline. The IGE channel sources from full parental DGE (biologically realistic — the parent's whole genome drives the parent's phenotype), but T/NT are stored separately so analysts can identify the pure indirect effect via Kong-style regression.

## Test plan

- [x] Smoke-tested 6 of the 7 collaborator parameter combos at `nfam=200` (popstrat deferred): all variance/correlation targets within Monte Carlo noise, T_mat+T_pat=DGE and PDGE-T=NT identities exact at machine precision.
- [x] Notebook executes end-to-end via `nbconvert --execute` (committed with outputs).
- [x] AM warnings fire correctly: silent at K=2 r=0.25 (feasible), construction + runtime warnings at K=2 r=0.75 (infeasible, R clamped from 1.48).
- [x] NTC regression at n=10k recovers theoretical T_mat / NT_m / NT_f coefficients to within ~1%.